### PR TITLE
ADD CMake SUPPORT

### DIFF
--- a/CC0.license
+++ b/CC0.license
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/CMake.README
+++ b/CMake.README
@@ -1,0 +1,19 @@
+Status
+======
+
+Currently the CMake build system only supports the win32 flavor of PDCurses.
+Furthermore it was only tested with MSVC and MinGW whereby the dlls produced
+by MinGW are for some unknown reason corrupted and cause a segfault very
+quickly.
+
+
+Usage
+=====
+
+Windows
+-------
+Use CMake to generate your project files. Compile and install PDCurses
+using the generated files.
+The install project creates a config-file package; so in order to use it
+from your CMake project, you only have to setup an enviroment variable
+PDCurses_DIR pointing to the install directory and call find_package(PDCurses).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,120 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann h.gassmann@online.de
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+cmake_minimum_required(VERSION 3.0)
+project(PDCurses VERSION 3.4)
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+	message(FATAL_ERROR "in-source builds are not supported!")
+endif()
+
+function(cat IN_FILE OUT_FILE)
+  file(READ ${IN_FILE} CONTENTS)
+  file(APPEND ${OUT_FILE} "${CONTENTS}")
+endfunction()
+
+set(PDCurses_PUBLIC_HEADERS
+    "${CMAKE_SOURCE_DIR}/curses.h"
+    "${CMAKE_SOURCE_DIR}/panel.h"
+    "${CMAKE_SOURCE_DIR}/term.h"
+)
+
+set(PDCurses_COMMON_SOURCES
+    ${PDCurses_PUBLIC_HEADERS}
+    "${CMAKE_SOURCE_DIR}/curspriv.h"
+    
+    "${CMAKE_SOURCE_DIR}/pdcurses/addch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/addchstr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/addstr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/attr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/beep.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/bkgd.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/border.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/clear.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/color.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/delch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/deleteln.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/deprec.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/getch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/getstr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/getyx.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/inch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/inchstr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/initscr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/inopts.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/insch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/insstr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/instr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/kernel.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/keyname.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/mouse.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/move.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/outopts.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/overlay.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/pad.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/panel.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/printw.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/refresh.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/scanw.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/scr_dump.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/scroll.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/slk.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/termattr.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/terminfo.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/touch.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/util.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/window.c"
+    "${CMAKE_SOURCE_DIR}/pdcurses/debug.c"
+)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+option(PDCurses_DEMO_PROJECTS "enable if you want to include the demo projects")
+
+if(WIN32)
+    option(PDCurses_WIN32_DLL "build the shared library version of pdcurses")
+    option(PDCurses_UNICODE "build the library with wide character support" ON)
+    option(PDCurses_UTF8 "treat narrow string content as utf8 (only effective if PDCurses_WIDE_API is turned on)" ON)
+    
+    if(MSVC)
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    endif()
+    
+    add_subdirectory(win32)
+else()
+    MESSAGE(FATAL_ERROR "your platform is currently not supported :(")
+endif()
+
+if(PDCurses_DEMO_PROJECTS)
+    add_subdirectory(demos)
+endif()
+
+########################################################################
+# install target
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/PDCursesConfigVersion.cmake"
+  VERSION ${PDCurses_VERSION}
+  COMPATIBILITY SameMajorVersion # I don't know how backwards compatible pdcurses is...
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/PDCursesConfigVersion.cmake" DESTINATION cmake)
+
+configure_file(cmake/PDCursesConfig.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/PDCursesConfig.cmake"
+  COPYONLY
+)
+install(FILES ${PDCurses_PUBLIC_HEADERS} DESTINATION include)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/PDCursesConfig.cmake" DESTINATION cmake)
+
+install(EXPORT PDCurses-targets DESTINATION cmake)

--- a/cmake/PDCursesConfig.cmake
+++ b/cmake/PDCursesConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/PDCurses-targets.cmake")

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann h.gassmann@online.de
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+
+add_executable(tuidemo
+    tui.h
+    tui.c
+    tuidemo.c
+)
+target_link_libraries(tuidemo PRIVATE PDCurses)
+target_include_directories(tuidemo PRIVATE "${CMAKE_SOURCE_DIR}")
+
+macro(add_demo NAME)
+    add_executable(${NAME} ${NAME}.c)
+    target_link_libraries(${NAME} PRIVATE PDCurses)
+    target_include_directories(${NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
+endmacro()
+
+add_demo(firework)
+
+add_demo(newdemo)
+
+add_demo(ptest)
+
+add_demo(rain)
+
+add_demo(testcurs)
+
+add_demo(worm)
+
+add_demo(xmas)

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann h.gassmann@online.de
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+
+if(PDCurses_WIN32_DLL)
+    set(PDCurses_LIBRARY_MODE SHARED)
+    
+    # generate the .def file
+    set(PDCurses_DEF_FILE "${CMAKE_CURRENT_BINARY_DIR}/pdcurses.def")
+    file(WRITE "${PDCurses_DEF_FILE}" "LIBRARY pdcurses\nEXPORTS\n")
+    cat("${CMAKE_SOURCE_DIR}/exp-base.def" "${PDCurses_DEF_FILE}")
+    if(PDCurses_UNICODE)
+        cat("${CMAKE_SOURCE_DIR}/exp-wide.def" "${PDCurses_DEF_FILE}")
+    endif()
+    
+    # pass the .def file to the linker
+    if(MSVC)
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEF:${PDCurses_DEF_FILE}")
+    elseif(MINGW)
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PDCurses_DEF_FILE}")
+    endif()
+else()
+    set(PDCurses_LIBRARY_MODE STATIC)
+    
+    # embed debug symbols in the static library
+    if(MSVC)
+        string(REGEX REPLACE "/Z[iI7]" "/Z7"
+            CMAKE_C_FLAGS_DEBUG
+            "${CMAKE_CXX_FLAGS_DEBUG}")
+        
+        string(REGEX REPLACE "/Z[iI7]" "/Z7"
+            CMAKE_C_FLAGS_RELWITHDEBINFO
+            "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    endif()
+endif()
+
+add_library(PDCurses ${PDCurses_LIBRARY_MODE}
+    ${PDCurses_COMMON_SOURCES}
+    
+    pdcwin.h
+    pdcclip.c
+    pdcdisp.c
+    pdcgetsc.c
+    pdckbd.c
+    pdcscrn.c
+    pdcsetsc.c
+    pdcutil.c
+    
+    # actually mingw could handle those resource files
+    # if we wouldn't call add_definitions(-municode)
+    $<$<C_COMPILER_ID:MSVC>:pdcurses.rc>
+)
+
+source_group(pdcurses REGULAR_EXPRESSION "${CMAKE_SOURCE_DIR}/pdcurses/.*")
+source_group(platform REGULAR_EXPRESSION "${CMAKE_SOURCE_DIR}/win32/.*")
+
+if(MINGW)
+    if(PDCurses_UNICODE)
+        add_definitions(-municode)
+    endif()
+    if(PDCurses_WIN32_DLL)
+        MESSAGE(FATAL_ERROR "MinGW currently produces corrupted dlls")
+        set_target_properties(PDCurses PROPERTIES PREFIX "")
+    endif()
+endif()
+
+target_compile_definitions(PDCurses
+    PRIVATE
+    $<$<BOOL:${PDCurses_UNICODE}>:PDC_WIDE _UNICODE>
+    $<$<BOOL:${PDCurses_UTF8}>:PDC_FORCE_UTF8>
+    
+    PUPLIC
+    $<$<BOOL:${PDCurses_WIN32_DLL}>:PDC_DLL_BUILD>
+    $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:PDCDEBUG>
+)
+
+target_include_directories(PDCurses
+    PRIVATE "${CMAKE_SOURCE_DIR}"
+)
+
+install(TARGETS PDCurses EXPORT PDCurses-targets
+    RUNTIME DESTINATION bin/$<CONFIG>
+    LIBRARY DESTINATION lib/$<CONFIG>
+    ARCHIVE DESTINATION lib/$<CONFIG>
+    INCLUDES DESTINATION include
+)

--- a/win32/pdcscrn.c
+++ b/win32/pdcscrn.c
@@ -1,6 +1,9 @@
 /* Public Domain Curses */
 
-#include "pdcwin.h"
+#include "pdcwin.h" 
+#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE
+#include <VersionHelpers.h>
+#endif
 
 #ifdef CHTYPE_LONG
 # define PDC_OFFSET 32
@@ -299,7 +302,13 @@ int PDC_scr_open(int argc, char **argv)
         exit(1);
     }
 
-    is_nt = !(GetVersion() & 0x80000000);
+    
+#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE
+    is_nt = IsWindowsVersionOrGreater( HIBYTE( _WIN32_WINNT_WIN2K ), LOBYTE( _WIN32_WINNT_WIN2K ), 0 );
+#else 
+    is_nt = !(GetVersion( ) & 0x80000000);
+#endif
+
 
     GetConsoleScreenBufferInfo(pdc_con_out, &csbi);
     GetConsoleScreenBufferInfo(pdc_con_out, &orig_scr);
@@ -396,7 +405,7 @@ int PDC_scr_open(int argc, char **argv)
 #ifdef PDCDEBUG
                 CHAR LastError[256];
 
-                FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, 
+                FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, 
                               GetLastError(), MAKELANGID(LANG_NEUTRAL, 
                               SUBLANG_DEFAULT), LastError, 256, NULL);
 

--- a/win32/pdcwin.h
+++ b/win32/pdcwin.h
@@ -1,6 +1,6 @@
 /* Public Domain Curses */
 
-#ifdef PDC_WIDE
+#if defined(PDC_WIDE) && !defined(UNICODE)
 # define UNICODE
 #endif
 


### PR DESCRIPTION
This adds CMake build scripts for the win32 flavor. As mentioned in the commit message and `CMake.README` the scope of the current implementation is quite limited and I don't plan to change this, but it is a reasonable foundation to start with if anyone wants/needs CMake support on any other platform.
