### PR TITLE
X11: blinking cursor

### DIFF
--- a/x11/pdcdisp.c
+++ b/x11/pdcdisp.c
@@ -80,6 +80,13 @@ int PDC_display_cursor(int oldrow, int oldcol, int newrow, int newcol,
     }
     else
     {
+        if ((oldrow == newrow) && (oldcol == newcol))
+        {
+            /* Do not send a message because it will cause the blink state
+               to reset. */
+            return OK;
+        }
+
         idx = CURSES_CURSOR;
         memcpy(buf, &idx, sizeof(int));
 


### PR DESCRIPTION
This appears to fix blinking cursor for clients that call move() more frequently than cursorBlinkRate.  Without this check, calling move() frequently (e.g. every 20 millis) results in a near-constantly-visible cursor with some snow/artifacts for the brief moments it disappears.
