### PR TITLE
set begx/begy to zero in newpad()

### DIFF
--- a/pdcurses/pad.c
+++ b/pdcurses/pad.c
@@ -82,7 +82,7 @@ WINDOW *newpad(int nlines, int ncols)
 
     PDC_LOG(("newpad() - called: lines=%d cols=%d\n", nlines, ncols));
 
-    if ( !(win = PDC_makenew(nlines, ncols, -1, -1))
+    if ( !(win = PDC_makenew(nlines, ncols, 0, 0))
         || !(win = PDC_makelines(win)) )
         return (WINDOW *)NULL;
 


### PR DESCRIPTION
begx and begy should be set to zero, otherwise creating a subpad
of the same width or height fails due to the check in subpad().