### PR TITLE
Fixes for wincon/pdcdisp.c

### DIFF
--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -213,6 +213,8 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
             mapped_attr |= COMMON_LVB_GRID_LVERTICAL;
         if (attr & A_RIGHT)
             mapped_attr |= COMMON_LVB_GRID_RVERTICAL;
+    } else {
+        mapped_attr = 0;
     }
 
     for (j = 0; j < len; j++)

--- a/wincon/pdcwin.h
+++ b/wincon/pdcwin.h
@@ -6,6 +6,23 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+/* missing definitions in old wincon.h */
+#ifndef COMMON_LVB_GRID_HORIZONTAL
+#define COMMON_LVB_GRID_HORIZONTAL	0x0400  /* Top horizontal */
+#endif
+#ifndef COMMON_LVB_GRID_LVERTICAL
+#define COMMON_LVB_GRID_LVERTICAL	0x0800	/* Left vertical */
+#endif
+#ifndef COMMON_LVB_GRID_RVERTICAL
+#define COMMON_LVB_GRID_RVERTICAL	0x1000	/* Right vertical */
+#endif
+#ifndef COMMON_LVB_REVERSE_VIDEO
+#define COMMON_LVB_REVERSE_VIDEO	0x4000	/* Reverse foreground and background attribute */
+#endif
+#ifndef COMMON_LVB_UNDERSCORE
+#define COMMON_LVB_UNDERSCORE	0x8000	/* Underscore */
+#endif
+/* missing definitions in old wincon.h end */
 #undef MOUSE_MOVED
 #include <curspriv.h>
 


### PR DESCRIPTION
* fix gcc warning about missing initialization
* fix compilation of pdcdisp.c with old wincon.h (found in older MinGW environments) by defining the new values in pdcwin.h