### PR TITLE
SDL renderers: use shaded font rendering

### DIFF
--- a/sdl1/pdcdisp.c
+++ b/sdl1/pdcdisp.c
@@ -200,7 +200,8 @@ void PDC_gotoyx(int row, int col)
 #ifdef PDC_WIDE
     chstr[0] = ch & A_CHARTEXT;
 
-    pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr, pdc_color[foregr]);
+    pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr, pdc_color[foregr],
+                                        pdc_color[backgr]);
     if (pdc_font)
     {
         dest.h = src.h;
@@ -248,7 +249,8 @@ static void _highlight(SDL_Rect *src, SDL_Rect *dest, chtype ch)
         if (col == -1)
             col = foregr;
 
-        pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr, pdc_color[col]);
+        pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                            pdc_color[col], pdc_color[backgr]);
         if (pdc_font)
         {
            src->x = 0;
@@ -379,8 +381,9 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
             ( ((ch & A_ITALIC) && (sysattrs & A_ITALIC)) ?
               TTF_STYLE_ITALIC : 0) );
 
-        pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
-                                           pdc_color[foregr]);
+        pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                           pdc_color[foregr],
+                                           pdc_color[backgr]);
 
         if (pdc_font)
         {

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -201,7 +201,8 @@ void PDC_gotoyx(int row, int col)
 #ifdef PDC_WIDE
     chstr[0] = ch & A_CHARTEXT;
 
-    pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr, pdc_color[foregr]);
+    pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr, pdc_color[foregr],
+                                        pdc_color[backgr]);
     if (pdc_font)
     {
         dest.h = src.h;
@@ -250,7 +251,8 @@ static void _highlight(SDL_Rect *src, SDL_Rect *dest, chtype ch)
         if (col == -1)
             col = foregr;
 
-        pdc_font = TTF_RenderText_Solid(pdc_ttffont, chstr, pdc_color[col]);
+        pdc_font = TTF_RenderText_Shaded(pdc_ttffont, chstr, pdc_color[col],
+                                         pdc_color[backgr]);
         if (pdc_font)
         {
             src->x = 0;
@@ -381,8 +383,9 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
             ( ((ch & A_ITALIC) && (sysattrs & A_ITALIC)) ?
               TTF_STYLE_ITALIC : 0) );
 
-        pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
-                                           pdc_color[foregr]);
+        pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                           pdc_color[foregr],
+                                           pdc_color[backgr]);
 
         if (pdc_font)
         {


### PR DESCRIPTION
Shaded font rendering improves the legibility of the text.

Result with TTF_RenderUNICODE_Solid with SDL2 on macOS 10.12.6:

![solid](https://user-images.githubusercontent.com/133402/38940201-e7981cbc-4329-11e8-9852-d7f9080412ac.png)


Result with TTF_RenderText_Shaded with SDL2 on macOS 10.12.6:

![shaded](https://user-images.githubusercontent.com/133402/38940211-eb6aecc0-4329-11e8-9f60-8e623d93a48d.png)
