### PR TITLE
Use safer SDL blitting to protect in case of resizing

### DIFF
--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -363,7 +363,7 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
             ch = (ch & (A_ATTRIBUTES ^ A_ALTCHARSET)) | acs_map[ch & 0x7f];
 #endif
         if (backgr == -1)
-            SDL_LowerBlit(pdc_tileback, &dest, pdc_screen, &dest);
+            SDL_BlitSurface(pdc_tileback, &dest, pdc_screen, &dest);
 
 #ifdef PDC_WIDE
         chstr[0] = ch & A_CHARTEXT;
@@ -390,7 +390,7 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
         src.x = (ch & 0xff) % 32 * pdc_fwidth;
         src.y = (ch & 0xff) / 32 * pdc_fheight;
 
-        SDL_LowerBlit(pdc_font, &src, pdc_screen, &dest);
+        SDL_BlitSurface(pdc_font, &src, pdc_screen, &dest);
 #endif
 
         if (!(blinked_off && (ch & A_BLINK) && (sysattrs & A_BLINK)) &&


### PR DESCRIPTION
This is for SDL2 and the bitmap font case. I have an occasional crash when I am resizing the window.
My program is configured to run with a 50ms `timeout` for `getch`.
AddressSanitizer report attached.

This is the code reference, a call of `SDL_LowerBlit`, which gets invoked by `getch` in my code (which I presume to happen in a case of `KEY_RESIZE`).

https://github.com/wmcbrine/PDCurses/blob/1169c14053c811720a043e7407b8a65f9d31cf23/sdl2/pdcdisp.c#L403

When this call is replaced with `SDL_BlitSurface`, which performs the clipping, the problem is solved.
I tried SDL2; this crash is likely to be also relevant to SDL1.

Would this be an acceptable fix?
I observed that `PDC_WIDE` did also use `SDL_BlitSurface` for the character drawing operation.

[PDC-crash.txt](https://github.com/wmcbrine/PDCurses/files/2037984/PDC-crash.txt)
