### PR TITLE
SDL2 Resizing

### DIFF
--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -345,7 +345,7 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
     _set_attr(attr);
 
     if (backgr == -1)
-        SDL_LowerBlit(pdc_tileback, &dest, pdc_screen, &dest);
+        SDL_BlitSurface(pdc_tileback, &dest, pdc_screen, &dest);
 #ifdef PDC_WIDE
     else
         SDL_FillRect(pdc_screen, &dest, pdc_mapped[backgr]);
@@ -394,7 +394,7 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
         src.x = (ch & 0xff) % 32 * pdc_fwidth;
         src.y = (ch & 0xff) / 32 * pdc_fheight;
 
-        SDL_LowerBlit(pdc_font, &src, pdc_screen, &dest);
+        SDL_BlitSurface(pdc_font, &src, pdc_screen, &dest);
 #endif
 
         if (!blink && (attr & (A_UNDERLINE | A_LEFT | A_RIGHT)))

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -78,6 +78,8 @@ static bool blinked_off = FALSE;
 
 void PDC_update_rects(void)
 {
+    int i;
+
     if (rectcount)
     {
         /* if the maximum number of rects has been reached, we're
@@ -86,7 +88,37 @@ void PDC_update_rects(void)
         if (rectcount == MAXRECT)
             SDL_UpdateWindowSurface(pdc_window);
         else
-            SDL_UpdateWindowSurfaceRects(pdc_window, uprect, rectcount);
+        {
+            for (i=0;i<rectcount;i++)
+            {
+                if (uprect[i].x > pdc_swidth  ||
+                    uprect[i].y > pdc_sheight ||
+                    !uprect[i].w || !uprect[i].h)
+                {
+                    if (i + 1 < rectcount)
+                    {
+                        memmove(uprect+i, uprect+i+1,
+                                (rectcount - i + 1) * sizeof(*uprect));
+                        --i;
+                    }
+                    rectcount--;
+                    continue;
+                }
+
+                if (uprect[i].x + uprect[i].w > pdc_swidth)
+                {
+                    uprect[i].w = min(pdc_swidth, pdc_swidth - uprect[i].x);
+                }
+
+                if (uprect[i].y + uprect[i].h > pdc_sheight)
+                {
+                    uprect[i].h = min(pdc_sheight, pdc_sheight - uprect[i].y);
+                }
+            }
+
+            if (rectcount > 0)
+                SDL_UpdateWindowSurfaceRects(pdc_window, uprect, rectcount);
+        }
 
         pdc_lastupdate = SDL_GetTicks();
         rectcount = 0;

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -191,8 +191,8 @@ void PDC_gotoyx(int row, int col)
     if (ch & A_ALTCHARSET && !(ch & 0xff80))
         ch = acs_map[ch & 0x7f];
 #endif
-    src.h = (SP->visibility == 1) ? pdc_fheight >> 2 : pdc_fheight;
-    src.w = pdc_fwidth;
+    dest.h = src.h = (SP->visibility == 1) ? pdc_fheight >> 2 : pdc_fheight;
+    dest.w = src.w = pdc_fwidth;
 
     dest.y = (row + 1) * pdc_fheight - src.h + pdc_yoffset;
     dest.x = col * pdc_fwidth + pdc_xoffset;
@@ -203,8 +203,6 @@ void PDC_gotoyx(int row, int col)
     pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr, pdc_color[foregr]);
     if (pdc_font)
     {
-        dest.h = src.h;
-        dest.w = src.w;
         src.x = 0;
         src.y = 0;
         SDL_FillRect(pdc_screen, &dest, pdc_mapped[backgr]);

--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -448,23 +448,16 @@ int PDC_get_key(void)
         {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
         case SDL_WINDOWEVENT_RESIZED:
-            if (pdc_own_window &&
-               (event.window.data2 / pdc_fheight != LINES ||
-                event.window.data1 / pdc_fwidth != COLS))
+            pdc_sheight = event.window.data2;
+            pdc_swidth = event.window.data1;
+            pdc_screen = SDL_GetWindowSurface(pdc_window);
+            SDL_UpdateWindowSurface(pdc_window);
+
+            if (!SP->resized)
             {
-                pdc_sheight = event.window.data2;
-                pdc_swidth = event.window.data1;
-
-                pdc_screen = SDL_GetWindowSurface(pdc_window);
-                touchwin(curscr);
-                wrefresh(curscr);
-
-                if (!SP->resized)
-                {
-                    SP->resized = TRUE;
-                    SP->key_code = TRUE;
-                    return KEY_RESIZE;
-                }
+                SP->resized = TRUE;
+                SP->key_code = TRUE;
+                return KEY_RESIZE;
             }
             break;
         case SDL_WINDOWEVENT_RESTORED:

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -270,6 +270,9 @@ int PDC_scr_open(int argc, char **argv)
                     SDL_GetError());
             return ERR;
         }
+
+        pdc_sheight = pdc_screen->h;
+        pdc_swidth  = pdc_screen->w;
     }
     else
     {


### PR DESCRIPTION
I was also having the same issue described in pull #35 and decided to take a stab at fixing it. The root of the problem is the lack of clipping when drawing, causing SDL to send PutImage requests that are outside the bounds of the actual window area. SDL_UpdateWindowSurfaceRects performs no clipping on the rects passed, thus I added some code to clip them (I did notice rects in the array with a width and/or height of 0 while debugging -- didn't look into that.)

I also fixed a spot where the dest rect's w/h aren't initialized, ensured that the window width and height are updated on resize events. Additionally, I added a couple lines to ensure that we know the actual window size after PDC_scr_open, as with my tiling WM, the window might not be guaranteed to be the size requested when SDL_CreateWindow is called.

This works when resizing in the application that I tested it with, and also the rain demo will resize nicely as long as LINES and COLS are >= 4.
