### PR TITLE
SDL2: Fix modifier keystroke handling

### DIFF
--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -233,7 +233,7 @@ static int _process_key_event(void)
         if (!(SDL_GetModState() & KMOD_NUM))
             pdc_key_modifiers &= ~PDC_KEY_MODIFIER_NUMLOCK;
 
-        if (SP->return_key_modifiers)
+        if (SP->return_key_modifiers && event.key.keysym.sym == oldkey)
         {
             SP->key_code = TRUE;
             switch (event.key.keysym.sym)
@@ -279,6 +279,7 @@ static int _process_key_event(void)
 #endif
     }
 
+    oldkey = event.key.keysym.sym;
     if (SDL_GetModState() & KMOD_NUM)
         pdc_key_modifiers |= PDC_KEY_MODIFIER_NUMLOCK;
 


### PR DESCRIPTION
This should fix the keystroke behavior. I compared the results of testcurs between the SDL1 and 2 ports, and this seems to be in line with what's expected.