### PR TITLE
various code cleanups done to coreboot's copy of PDCurses

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -1,7 +1,7 @@
 PDCurses common files
 =====================
 
-This directory is for files which are platform-specific, yet shared by 
+This directory is for files which are platform-specific, yet shared by
 more than one platform, in contrast to the "common core" in ../pdcurses.
 
 

--- a/pdcurses/getyx.c
+++ b/pdcurses/getyx.c
@@ -137,9 +137,14 @@ int setsyx(int y, int x)
         curscr->_leaveit = TRUE;
         return OK;
     }
+    else if (y == -1 || x == -1)
+    {
+        return OK;
+    }
     else
     {
         curscr->_leaveit = FALSE;
-        return wmove(curscr, y, x);
+        wmove(curscr, y, x);
+	return OK;
     }
 }

--- a/pdcurses/initscr.c
+++ b/pdcurses/initscr.c
@@ -111,6 +111,9 @@ MOUSE_STATUS Mouse_status, pdc_mouse_status;
 extern RIPPEDOFFLINE linesripped[5];
 extern char linesrippedoff;
 
+#ifndef XCURSES
+static
+#endif
 WINDOW *Xinitscr(int argc, char *argv[])
 {
     int i;

--- a/pdcurses/window.c
+++ b/pdcurses/window.c
@@ -306,9 +306,7 @@ int mvwin(WINDOW *win, int y, int x)
 WINDOW *subwin(WINDOW *orig, int nlines, int ncols, int begy, int begx)
 {
     WINDOW *win;
-    int i;
-    int j = begy - orig->_begy;
-    int k = begx - orig->_begx;
+    int i, j, k;
 
     PDC_LOG(("subwin() - called: lines %d cols %d begy %d begx %d\n",
              nlines, ncols, begy, begx));
@@ -319,6 +317,9 @@ WINDOW *subwin(WINDOW *orig, int nlines, int ncols, int begy, int begx)
         (begy + nlines) > (orig->_begy + orig->_maxy) ||
         (begx + ncols) > (orig->_begx + orig->_maxx))
         return (WINDOW *)NULL;
+
+    j = begy - orig->_begy;
+    k = begx - orig->_begx;
 
     if (!nlines)
         nlines = orig->_maxy - 1 - j;

--- a/x11/configure
+++ b/x11/configure
@@ -6074,4 +6074,3 @@ $as_echo "#define USE_NEXTAW /**/" >>confdefs.h
 
 
 $as_echo "#define XPOINTER_TYPEDEFED /**/" >>confdefs.h
-


### PR DESCRIPTION
Some of them were finds by [coverity](https://scan.coverity.com), other are rather ordinary cleanups (eg. trailing whitespace)