### PR TITLE
set LD_RXLIB1 on OpenBSD

### DIFF
--- a/x11/aclocal.m4
+++ b/x11/aclocal.m4
@@ -378,7 +378,7 @@ case "$target" in
 		SYS_DEFS="-DSUNOS -DSUNOS_STRTOD_BUG"
 		LD_RXLIB1="ld"
 		;;
-	*linux*|*atheos*|*nto-qnx*)
+	*linux*|*atheos*|*nto-qnx*|*openbsd*)
 		LD_RXLIB1="${CC} -shared"
 		;;
 	*freebsd*)


### PR DESCRIPTION
otherwise `LD_RXLIB1` is unset and `./configure; gmake` bombs out. this probably will require re-running auto* tools to rebuild things so the change is visible to `./configure` but I'm not sure how you're using the auto* tools

works with CC=gcc (the default that `./configure` picks up on) have not tested with CC=clang