### PR TITLE
New port: DOSVGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ platforms.
 Build instructions are in the README.md file for each platform:
 
 -  [DOS]
+-  [DOS with full VGA support]
 -  [OS/2]
 -  [SDL 1.x]
 -  [SDL 2.x]
@@ -58,6 +59,7 @@ William McBrine <wmcbrine@gmail.com>
 [History]: docs/HISTORY.md
 [docs]: docs/README.md
 [DOS]: dos/README.md
+[DOS with full VGA support]: dosvga/README.md
 [OS/2]: os2/README.md
 [SDL 1.x]: sdl1/README.md
 [SDL 2.x]: sdl2/README.md

--- a/demos/testcurs.c
+++ b/demos/testcurs.c
@@ -1209,7 +1209,7 @@ void gradient(int tmarg)
         move(tmarg + 3 + i, (COLS - 69) / 2);
         for (j = 0; j < len; j++)
         {
-            const int oval = j * 1000 / len;
+            const int oval = (int)(j * 1000L / len);
             const int reverse = 1000 - oval;
 
             if (!i)

--- a/dosvga/Makefile
+++ b/dosvga/Makefile
@@ -1,0 +1,85 @@
+# GNU Makefile for PDCurses - DOS
+#
+# Usage: make [-f path\Makefile] [DEBUG=Y] [target]
+#
+# where target can be any of:
+# [all|libs|demos|pdcurses.a|testcurs.exe...]
+
+O = o
+E = .exe
+RM = del
+
+ifndef PDCURSES_SRCDIR
+	PDCURSES_SRCDIR = ..
+endif
+
+include $(PDCURSES_SRCDIR)/common/libobjs.mif
+
+osdir		= $(PDCURSES_SRCDIR)/dosvga
+
+PDCURSES_DOS_H	= $(osdir)/pdcdos.h
+
+CC		= gcc
+
+ifeq ($(DEBUG),Y)
+	CFLAGS  = -g -Wall -DPDCDEBUG
+	LDFLAGS = -g
+else
+	CFLAGS  = -O2 -Wall
+	LDFLAGS =
+endif
+
+CFLAGS += -I$(PDCURSES_SRCDIR)
+
+LINK		= gcc
+
+LIBEXE		= ar
+LIBFLAGS	= rcv
+
+LIBCURSES	= pdcurses.a
+
+.PHONY: all libs clean demos dist
+
+all:	libs
+
+libs:	$(LIBCURSES)
+
+clean:
+	-$(RM) *.o
+	-$(RM) *.a
+	-$(RM) *.exe
+
+demos:	$(DEMOS)
+ifneq ($(DEBUG),Y)
+	strip *.exe
+endif
+
+$(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
+	$(LIBEXE) $(LIBFLAGS)S $@ addch.o addchstr.o addstr.o attr.o beep.o bkgd.o border.o clear.o color.o debug.o delch.o deleteln.o
+	$(LIBEXE) $(LIBFLAGS)S $@ getch.o getstr.o getyx.o inch.o inchstr.o initscr.o inopts.o insch.o insstr.o instr.o kernel.o keyname.o
+	$(LIBEXE) $(LIBFLAGS)S $@ mouse.o move.o outopts.o overlay.o pad.o panel.o pdcclip.o pdcdisp.o pdcgetsc.o pdckbd.o pdcscrn.o pdcsetsc.o
+	$(LIBEXE) $(LIBFLAGS)  $@ pdcutil.o printw.o refresh.o scanw.o scr_dump.o scroll.o slk.o termattr.o touch.o util.o window.o
+
+$(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
+$(PDCOBJS) : $(PDCURSES_DOS_H)
+$(DEMOS) : $(PDCURSES_CURSES_H) $(LIBCURSES)
+panel.o : $(PANEL_HEADER)
+
+$(LIBOBJS) : %.o: $(srcdir)/%.c
+	$(CC) -c $(CFLAGS) $<
+
+$(PDCOBJS) : %.o: $(osdir)/%.c
+	$(CC) -c $(CFLAGS) $<
+
+firework.exe ozdemo.exe rain.exe testcurs.exe worm.exe xmas.exe \
+ptest.exe: %.exe: $(demodir)/%.c
+	$(CC) $(CFLAGS) -o$@ $< $(LIBCURSES)
+
+tuidemo.exe: tuidemo.o tui.o
+	$(LINK) $(LDFLAGS) -o$@ tuidemo.o tui.o $(LIBCURSES)
+
+tui.o: $(demodir)/tui.c $(demodir)/tui.h $(PDCURSES_CURSES_H)
+	$(CC) -c $(CFLAGS) -I$(demodir) -o$@ $<
+
+tuidemo.o: $(demodir)/tuidemo.c $(PDCURSES_CURSES_H)
+	$(CC) -c $(CFLAGS) -I$(demodir) -o$@ $<

--- a/dosvga/Makefile.bcc
+++ b/dosvga/Makefile.bcc
@@ -1,0 +1,76 @@
+# Borland Makefile for PDCurses - DOS
+#
+# Usage: make -f [path\]Makefile.bcc [DEBUG=] [MODEL=c|h|l|m|s] [target]
+#
+# where target can be any of:
+# [all|demos|pdcurses.lib|testcurs.exe...]
+
+!ifndef MODEL
+MODEL = l
+!endif
+
+O = obj
+E = .exe
+RM = del
+
+!ifndef PDCURSES_SRCDIR
+PDCURSES_SRCDIR = ..
+!endif
+
+!include $(PDCURSES_SRCDIR)\common\libobjs.mif
+
+osdir		= $(PDCURSES_SRCDIR)\dosvga
+
+!ifdef DEBUG
+CFLAGS		= -N -v -y -DPDCDEBUG
+!else
+CFLAGS		= -O
+!endif
+
+CPPFLAGS	= -I$(PDCURSES_SRCDIR)
+
+BUILD		= $(CC) -1- -G -d -w-par -c -m$(MODEL) $(CFLAGS) $(CPPFLAGS)
+
+LIBEXE		= tlib /C /E
+
+LIBCURSES	= pdcurses.lib
+
+all:	$(LIBCURSES)
+
+clean:
+	-$(RM) *.obj
+	-$(RM) *.lib
+	-$(RM) *.map
+	-$(RM) *.exe
+
+demos:	$(LIBCURSES) $(DEMOS)
+
+$(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
+	-$(RM) $@
+	$(LIBEXE) $@ @$(PDCURSES_SRCDIR)\common\borland.lrf
+
+.autodepend
+
+{$(srcdir)\}.c.obj:
+	$(BUILD) $<
+
+{$(osdir)\}.c.obj:
+	$(BUILD) $<
+
+{$(demodir)\}.c.obj:
+	$(BUILD) $<
+
+.c.obj:
+	$(BUILD) $<
+
+.obj.exe:
+	$(CC) -m$(MODEL) -e$@ $** $(LIBCURSES)
+
+tuidemo.exe:	tuidemo.obj tui.obj $(LIBCURSES)
+	$(CC) -m$(MODEL) -e$@ $**
+
+tui.obj: $(demodir)\tui.c $(demodir)\tui.h $(PDCURSES_CURSES_H)
+	$(BUILD) -I$(demodir) $(demodir)\tui.c
+
+tuidemo.obj: $(demodir)\tuidemo.c $(PDCURSES_CURSES_H)
+	$(BUILD) -I$(demodir) $(demodir)\tuidemo.c

--- a/dosvga/Makefile.wcc
+++ b/dosvga/Makefile.wcc
@@ -1,0 +1,35 @@
+# Watcom Makefile for PDCurses - DOS
+#
+# Usage: wmake -f [path\]Makefile.wcc [DEBUG=Y] [MODEL=c|h|l|m|s|f] [target]
+#
+# where target can be any of:
+# [all|demos|pdcurses.lib|testcurs.exe...]
+
+!ifndef MODEL
+MODEL		= l
+!endif
+
+!ifdef %PDCURSES_SRCDIR
+PDCURSES_SRCDIR	= $(%PDCURSES_SRCDIR)
+!else
+PDCURSES_SRCDIR	= ..
+!endif
+
+osdir		= $(PDCURSES_SRCDIR)/dosvga
+
+!ifeq MODEL f
+CC		= wcc386
+TARGET		= dos4g
+!else
+CC		= wcc
+TARGET		= dos
+!endif
+
+CFLAGS		= -bt=$(TARGET) -m$(MODEL)
+
+!include $(PDCURSES_SRCDIR)/common/watcom.mif
+
+$(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
+	%write wccdos.lrf $(LIBOBJS) $(PDCOBJS)
+	$(LIBEXE) $@ @wccdos.lrf
+	-$(RM) wccdos.lrf

--- a/dosvga/README.md
+++ b/dosvga/README.md
@@ -1,0 +1,47 @@
+PDCurses for DOS
+================
+
+This directory contains PDCurses source code files specific to DOS.
+
+
+Building
+--------
+
+- Choose the appropriate makefile for your compiler:
+
+        Makefile     - DJGPP
+        Makefile.bcc - Borland C++
+        Makefile.wcc - Watcom
+
+- For 16-bit compilers, you can change the memory MODEL as a command-
+  line option. (Large model is the default, and recommended.) With
+  Watcom, specifying "MODEL=f" (flat) will automatically switch to a
+  32-bit build.
+
+- Optionally, you can build in a different directory than the platform
+  directory by setting PDCURSES_SRCDIR to point to the directory where
+  you unpacked PDCurses, and changing to your target directory:
+
+        set PDCURSES_SRCDIR=c:\pdcurses
+
+- Build it:
+
+        make -f makefile
+
+  (For Watcom, use "wmake" instead of "make".) You'll get the library
+  (pdcurses.lib or .a, depending on your compiler) and a lot of object
+  files. Add the target "demos" to build the sample programs.
+
+
+Distribution Status
+-------------------
+
+The files in this directory are released to the public domain.
+
+
+Acknowledgements
+----------------
+
+Watcom C port was provided by Pieter Kunst <kunst@prl.philips.nl>
+
+DJGPP port was provided by David Nugent <davidn@csource.oz.au>

--- a/dosvga/README.md
+++ b/dosvga/README.md
@@ -1,7 +1,8 @@
 PDCurses for DOS
 ================
 
-This directory contains PDCurses source code files specific to DOS.
+This directory contains PDCurses source code files specific to the
+VGA-capable DOS port.
 
 
 Building

--- a/dosvga/pdcclip.c
+++ b/dosvga/pdcclip.c
@@ -1,0 +1,132 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+#include <stdlib.h>
+
+/*man-start**************************************************************
+
+clipboard
+---------
+
+### Synopsis
+
+    int PDC_getclipboard(char **contents, long *length);
+    int PDC_setclipboard(const char *contents, long length);
+    int PDC_freeclipboard(char *contents);
+    int PDC_clearclipboard(void);
+
+### Description
+
+   PDC_getclipboard() gets the textual contents of the system's
+   clipboard. This function returns the contents of the clipboard in the
+   contents argument. It is the responsibility of the caller to free the
+   memory returned, via PDC_freeclipboard(). The length of the clipboard
+   contents is returned in the length argument.
+
+   PDC_setclipboard copies the supplied text into the system's
+   clipboard, emptying the clipboard prior to the copy.
+
+   PDC_clearclipboard() clears the internal clipboard.
+
+### Return Values
+
+    indicator of success/failure of call.
+    PDC_CLIP_SUCCESS        the call was successful
+    PDC_CLIP_MEMORY_ERROR   unable to allocate sufficient memory for
+                            the clipboard contents
+    PDC_CLIP_EMPTY          the clipboard contains no text
+    PDC_CLIP_ACCESS_ERROR   no clipboard support
+
+### Portability
+                             X/Open  ncurses  NetBSD
+    PDC_getclipboard            -       -       -
+    PDC_setclipboard            -       -       -
+    PDC_freeclipboard           -       -       -
+    PDC_clearclipboard          -       -       -
+
+**man-end****************************************************************/
+
+/* global clipboard contents, should be NULL if none set */
+
+static char *pdc_DOS_clipboard = NULL;
+
+int PDC_getclipboard(char **contents, long *length)
+{
+    int len;
+
+    PDC_LOG(("PDC_getclipboard() - called\n"));
+
+    if (!pdc_DOS_clipboard)
+        return PDC_CLIP_EMPTY;
+
+    len = strlen(pdc_DOS_clipboard);
+    *contents = malloc(len + 1);
+    if (!*contents)
+        return PDC_CLIP_MEMORY_ERROR;
+
+    strcpy(*contents, pdc_DOS_clipboard);
+    *length = len;
+
+    return PDC_CLIP_SUCCESS;
+}
+
+int PDC_setclipboard(const char *contents, long length)
+{
+    PDC_LOG(("PDC_setclipboard() - called\n"));
+
+    if (pdc_DOS_clipboard)
+    {
+        free(pdc_DOS_clipboard);
+        pdc_DOS_clipboard = NULL;
+    }
+
+    if (contents)
+    {
+        pdc_DOS_clipboard = malloc(length + 1);
+        if (!pdc_DOS_clipboard)
+            return PDC_CLIP_MEMORY_ERROR;
+
+        strcpy(pdc_DOS_clipboard, contents);
+    }
+
+    return PDC_CLIP_SUCCESS;
+}
+
+int PDC_freeclipboard(char *contents)
+{
+    PDC_LOG(("PDC_freeclipboard() - called\n"));
+
+    /* should we also free empty the system clipboard? probably not */
+
+    if (contents)
+    {
+        /* NOTE: We free the memory, but we can not set caller's pointer
+           to NULL, so if caller calls again then will try to access
+           free'd memory.  We 1st overwrite memory with a string so if
+           caller tries to use free memory they won't get what they
+           expect & hopefully notice. */
+
+        /* memset(contents, 0xFD, strlen(contents)); */
+
+        if (strlen(contents) >= strlen("PDCURSES"))
+            strcpy(contents, "PDCURSES");
+
+        free(contents);
+    }
+
+    return PDC_CLIP_SUCCESS;
+}
+
+int PDC_clearclipboard(void)
+{
+    PDC_LOG(("PDC_clearclipboard() - called\n"));
+
+    if (pdc_DOS_clipboard)
+    {
+        free(pdc_DOS_clipboard);
+        pdc_DOS_clipboard = NULL;
+    }
+
+    return PDC_CLIP_SUCCESS;
+}

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -97,7 +97,13 @@ static void _new_packet(unsigned long colors, int lineno, int x, int len, const 
                 else if (line == underline && (glyph & A_UNDERLINE) != 0)
                     byte = 0xFF;
                 else
+                {
                     byte = getdosmembyte(PDC_state.font_addr + ch*_FONT16 + line);
+                    if (glyph & A_LEFT)
+                        byte |= 0x80;
+                    if (glyph & A_RIGHT)
+                        byte |= 0x01;
+                }
                 if (pass & 1)
                     byte = ~byte;
 
@@ -179,6 +185,11 @@ static void _transform_line_8(int lineno, int x, int len, const chtype *srcp)
                 byte = 0xFF;
             else
                 byte = getdosmembyte(PDC_state.font_addr + ch*_FONT16 + line);
+            /* Bit mask for A_LEFT and A_RIGHT */
+            if (glyph & A_LEFT)
+                byte |= 0x80;
+            if (glyph & A_RIGHT)
+                byte |= 0x01;
 
             /* Get the colors */
             colors = _get_colors(glyph);
@@ -638,7 +649,7 @@ static unsigned short _video_read_word(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
     unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
-    unsigned short word = getdosmembyte(addr2);
+    unsigned short word = getdosmemword(addr2);
     return word;
 }
 

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -3,6 +3,13 @@
 #include "pdcdos.h"
 #include "../common/acs437.h"
 
+#ifdef __WATCOMC__
+/* For Watcom, we need conio.h, but the Curses macro for getch fouls it up */
+#undef getch
+#include <conio.h>
+#define outportb(a, b) outp((a), (b))
+#endif
+
 /* Support cursor on graphics mode */
 static unsigned long bytes_behind[8][16];
 static unsigned char cursor_color = 15;
@@ -667,15 +674,15 @@ static unsigned _set_window(unsigned window, unsigned long addr)
     if (addr < offset || offset + PDC_state.window_size <= addr)
     {
         /* Need to move the window */
-        __dpmi_regs regs;
+        PDCREGS regs;
         unsigned long gran = PDC_state.window_gran * 1024L;
 
         memset(&regs, 0, sizeof(regs));
-        regs.x.ax = 0x4F05;
-        regs.x.bx = window;
-        regs.x.dx = addr / gran;
-        offset = regs.x.dx * gran;
-        __dpmi_int(0x10, &regs);
+        regs.W.ax = 0x4F05;
+        regs.W.bx = window;
+        regs.W.dx = addr / gran;
+        offset = regs.W.dx * gran;
+        PDCINT(0x10, regs);
         PDC_state.offset[window] = offset;
     }
 

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -158,7 +158,7 @@ static void _transform_line_8(int lineno, int x, int len, const chtype *srcp)
     for (line = 0; line < _FONT16; line++)
     {
         int col;
-        unsigned addr2 = addr;
+        unsigned long addr2 = addr;
 
         /* Loop by column */
         for (col = 0; col < len; col++)
@@ -285,7 +285,7 @@ static unsigned long _get_colors(chtype glyph)
     }
 
     /* Return them as a pair */
-    return (back << 16) | fore;
+    return ((unsigned long)back << 16) | fore;
 }
 
 static void _cursor_off_4(void)
@@ -580,26 +580,26 @@ void PDC_private_cursor_on(int row, int col)
 
 static unsigned long _address_4(int row, int col)
 {
-    return row * PDC_state.bytes_per_line * _FONT16 + col;
+    return (unsigned long)row * PDC_state.bytes_per_line * _FONT16 + col;
 }
 
 static unsigned long _address_8(int row, int col)
 {
-    return row * PDC_state.bytes_per_line * _FONT16
+    return (unsigned long)row * PDC_state.bytes_per_line * _FONT16
             + col * 8 * ((PDC_state.bits_per_pixel + 7)/8);
 }
 
 static void _video_write_byte(unsigned long addr, unsigned char byte)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.write_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmembyte(addr2, byte);
 }
 
 static void _video_write_word(unsigned long addr, unsigned short word)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.write_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmemword(addr2, word);
 }
 
@@ -622,14 +622,14 @@ static void _video_write_3byte(unsigned long addr, unsigned long byte3)
 static void _video_write_dword(unsigned long addr, unsigned long dword)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.write_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmemdword(addr2, dword);
 }
 
 static unsigned char _video_read_byte(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.read_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned char byte = getdosmembyte(addr2);
     return byte;
 }
@@ -637,7 +637,7 @@ static unsigned char _video_read_byte(unsigned long addr)
 static unsigned short _video_read_word(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.read_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned short word = getdosmembyte(addr2);
     return word;
 }
@@ -663,7 +663,7 @@ static unsigned long _video_read_3byte(unsigned long addr)
 static unsigned long _video_read_dword(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = PDC_state.window[PDC_state.read_win]*16L + offset;
+    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned long dword = getdosmemdword(addr2);
     return dword;
 }

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -1,0 +1,232 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+#include "../common/acs437.h"
+
+/* Support cursor on graphics mode */
+static unsigned char bytes_behind[4][16];
+static unsigned char cursor_color = 15;
+static void draw_glyph(int row, int col, chtype glyph);
+static unsigned long address(int row, int col);
+static void video_write_byte(unsigned long addr, unsigned char byte);
+static unsigned char video_read_byte(unsigned long addr);
+
+/* position hardware cursor at (y, x) */
+
+void PDC_gotoyx(int row, int col)
+{
+    if (PDC_state.cursor_visible)
+        PDC_private_cursor_off();
+    PDC_private_cursor_on(row, col);
+}
+
+/* update the given physical line to look like the corresponding line in
+   curscr */
+
+void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
+{
+    int i;
+
+    PDC_LOG(("PDC_transform_line() - called: lineno=%d\n", lineno));
+
+    for (i = 0; i < len; i++)
+    {
+        draw_glyph(lineno, x + i, srcp[i]);
+        if (lineno == PDC_state.cursor_row && x + i == PDC_state.cursor_col)
+            PDC_private_cursor_on(PDC_state.cursor_row, PDC_state.cursor_col);
+    }
+    outportb(0x3c4, 2);
+    outportb(0x3c5, 0xF);
+}
+
+void PDC_doupdate(void)
+{
+}
+
+static void draw_glyph(int row, int col, chtype glyph)
+{
+    unsigned long addr = address(row, col);
+    unsigned long font_addr;
+    attr_t attr;
+    unsigned long cp;
+    unsigned char ch;
+    short fore, back;
+    unsigned char vplane;
+    int line;
+    int underline;
+    unsigned char fnt;
+
+    /* Get the foreground and background colors */
+    attr = glyph & (A_ATTRIBUTES ^ A_ALTCHARSET);
+    pair_content(PAIR_NUMBER(attr), &fore, &back);
+
+    if (attr & A_BOLD)
+        fore |= 8;
+    if (attr & A_BLINK)
+        back |= 8;
+
+    fore = PDC_state.pdc_curstoreal[fore];
+    back = PDC_state.pdc_curstoreal[back];
+
+    if (attr & A_REVERSE)
+    {
+        short swap = fore;
+        fore = back;
+        back = swap;
+    }
+
+    /* Set underline if requested */
+    underline = (attr & A_UNDERLINE) ? 13 /*_FONT16*/ : -1;
+
+    /* Get the index into the font */
+    ch = glyph & 0xFF;
+    if (glyph & A_ALTCHARSET && !(glyph & 0xff80))
+        ch = acs_map[ch & 0x7f] & 0xff;
+
+    /* Get the address of the glyph in memory */
+    font_addr = PDC_state.font_addr + ch * _FONT16;
+
+    /* Planes where fore has 0 and back has 0 */
+    vplane = ~fore & ~back & 0xF;
+    if (vplane != 0) {
+        outportb(0x3c4, 2);
+        outportb(0x3c5, vplane);
+        cp = addr;
+        for (line = 0; line < _FONT16; ++line) {
+            fnt = 0x00;
+            video_write_byte(cp, fnt);
+            cp += PDC_state.bytes_per_line;
+        }
+    }
+    /* Planes where fore has 1 and back has 0 */
+    vplane =  fore & ~back & 0xF;
+    if (vplane != 0) {
+        outportb(0x3c4, 2);
+        outportb(0x3c5, vplane);
+        cp = addr;
+        for (line = 0; line < _FONT16; ++line) {
+            if (line == underline)
+                fnt = 0xFF;
+            else
+                fnt = getdosmembyte(font_addr + line);
+            video_write_byte(cp, fnt);
+            cp += PDC_state.bytes_per_line;
+        }
+    }
+    /* Planes where fore has 0 and back has 1 */
+    vplane = ~fore &  back & 0xF;
+    if (vplane != 0) {
+        outportb(0x3c4, 2);
+        outportb(0x3c5, vplane);
+        cp = addr;
+        for (line = 0; line < _FONT16; ++line) {
+            if (line == underline)
+                fnt = 0x00;
+            else
+                fnt = ~getdosmembyte(font_addr + line);
+            video_write_byte(cp, fnt);
+            cp += PDC_state.bytes_per_line;
+        }
+    }
+    /* Planes where fore has 1 and back has 1 */
+    vplane =  fore &  back & 0xF;
+    if (vplane != 0) {
+        outportb(0x3c4, 2);
+        outportb(0x3c5, vplane);
+        cp = addr;
+        for (line = 0; line < _FONT16; ++line) {
+            fnt = 0xFF;
+            video_write_byte(cp, fnt);
+            cp += PDC_state.bytes_per_line;
+        }
+    }
+}
+
+void PDC_private_cursor_off(void)
+{
+    if (PDC_state.cursor_visible && PDC_state.cursor_row < (unsigned)LINES
+    &&  PDC_state.cursor_col < (unsigned)COLS) {
+        unsigned long addr = address(PDC_state.cursor_row, PDC_state.cursor_col);
+        unsigned plane;
+        unsigned line;
+
+        for (plane = 0; plane < 4; ++plane)
+        {
+            unsigned long p = addr;
+            outportb(0x03C4, 2);
+            outportb(0x03C5, 1 << plane);
+            for (line = 0; line < _FONT16; ++line)
+            {
+                video_write_byte(p, bytes_behind[plane][line]);
+                p += PDC_state.bytes_per_line;
+            }
+        }
+    }
+    PDC_state.cursor_visible = FALSE;
+}
+
+void PDC_private_cursor_on(int row, int col)
+{
+    unsigned long addr = address(row, col);
+    unsigned long p;
+    unsigned plane;
+    unsigned line;
+
+    for (plane = 0; plane < 4; ++plane)
+    {
+        p = addr;
+        outportb(0x03CE, 4);
+        outportb(0x03CF, plane);
+        for (line = 0; line < _FONT16; ++line)
+        {
+            bytes_behind[plane][line] = video_read_byte(p);
+            p += PDC_state.bytes_per_line;
+        }
+    }
+    outportb(0x03C5, 2);
+    outportb(0x03C5,  cursor_color);
+    p = address(row, col);
+    p += PDC_state.cursor_start * PDC_state.bytes_per_line;
+    for (line = PDC_state.cursor_start; line <= PDC_state.cursor_end; ++line)
+    {
+        video_write_byte(p, 0xFF);
+        p += PDC_state.bytes_per_line;
+    }
+    outportb(0x03C5, 2);
+    outportb(0x03C5, ~cursor_color);
+    p = address(row, col);
+    p += PDC_state.cursor_start * PDC_state.bytes_per_line;
+    for (line = PDC_state.cursor_start; line <= PDC_state.cursor_end; ++line)
+    {
+        video_write_byte(p, 0x00);
+        p += PDC_state.bytes_per_line;
+    }
+    outportb(0x03C5, 2);
+    outportb(0x03C5, 0xF);
+    PDC_state.cursor_visible = TRUE;
+    PDC_state.cursor_row = row;
+    PDC_state.cursor_col = col;
+}
+
+static unsigned long address(int row, int col)
+{
+    return row * PDC_state.bytes_per_line * _FONT16 + col;
+}
+
+static void video_write_byte(unsigned long addr, unsigned char byte)
+{
+    /* TODO: support VESA modes */
+    if (addr < 0x10000)
+        setdosmembyte(0xA0000 + addr, byte);
+}
+
+static unsigned char video_read_byte(unsigned long addr)
+{
+    /* TODO: support VESA modes */
+    unsigned char byte;
+    if (addr < 0x10000)
+        byte = getdosmembyte(0xA0000 + addr);
+    else
+        byte = 0;
+    return byte;
+}

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -592,14 +592,14 @@ static unsigned long _address_8(int row, int col)
 static void _video_write_byte(unsigned long addr, unsigned char byte)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmembyte(addr2, byte);
 }
 
 static void _video_write_word(unsigned long addr, unsigned short word)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmemword(addr2, word);
 }
 
@@ -622,14 +622,14 @@ static void _video_write_3byte(unsigned long addr, unsigned long byte3)
 static void _video_write_dword(unsigned long addr, unsigned long dword)
 {
     unsigned offset = _set_window(PDC_state.write_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.write_win], offset);
     setdosmemdword(addr2, dword);
 }
 
 static unsigned char _video_read_byte(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned char byte = getdosmembyte(addr2);
     return byte;
 }
@@ -637,7 +637,7 @@ static unsigned char _video_read_byte(unsigned long addr)
 static unsigned short _video_read_word(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned short word = getdosmembyte(addr2);
     return word;
 }
@@ -663,7 +663,7 @@ static unsigned long _video_read_3byte(unsigned long addr)
 static unsigned long _video_read_dword(unsigned long addr)
 {
     unsigned offset = _set_window(PDC_state.read_win, addr);
-    unsigned long addr2 = _FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
+    unsigned long addr2 = (unsigned long)_FAR_POINTER(PDC_state.window[PDC_state.read_win], offset);
     unsigned long dword = getdosmemdword(addr2);
     return dword;
 }

--- a/dosvga/pdcdisp.c
+++ b/dosvga/pdcdisp.c
@@ -97,10 +97,18 @@ static void _new_packet(unsigned colors, int lineno, int x, int len, const chtyp
 
 void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
 {
+    bool redraw_cursor;
     unsigned old_colors, colors;
     int i, j;
 
     PDC_LOG(("PDC_transform_line() - called: lineno=%d\n", lineno));
+
+    redraw_cursor = PDC_state.cursor_visible
+                 && lineno == PDC_state.cursor_row
+                 && x <= PDC_state.cursor_col
+                 && PDC_state.cursor_col < x + len;
+    if (redraw_cursor)
+        PDC_private_cursor_off();
 
     /* Draw runs of characters that have the same colors */
     old_colors = _get_colors(srcp[0]);
@@ -122,8 +130,7 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
     _new_packet(old_colors, lineno, x, i, srcp);
 
     /* Redraw the cursor if it has been erased */
-    if (lineno == PDC_state.cursor_row
-    &&  x <= PDC_state.cursor_col && PDC_state.cursor_col < x + len)
+    if (redraw_cursor)
         PDC_private_cursor_on(PDC_state.cursor_row, PDC_state.cursor_col);
 
     /* Reset the VGA plane register to its normal state */

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -1,0 +1,206 @@
+/* PDCurses */
+
+#include <curspriv.h>
+#include <string.h>
+
+/*----------------------------------------------------------------------
+ *  MEMORY MODEL SUPPORT:
+ *
+ *  MODELS
+ *    TINY    cs,ds,ss all in 1 segment (not enough memory!)
+ *    SMALL   cs:1 segment, ds:1 segment
+ *    MEDIUM  cs:many segments, ds:1 segment
+ *    COMPACT cs:1 segment, ds:many segments
+ *    LARGE   cs:many segments, ds:many segments
+ *    HUGE    cs:many segments, ds:segments > 64K
+ */
+
+#ifdef __TINY__
+# define SMALL 1
+#endif
+#ifdef __SMALL__
+# define SMALL 1
+#endif
+#ifdef __MEDIUM__
+# define MEDIUM 1
+#endif
+#ifdef __COMPACT__
+# define COMPACT 1
+#endif
+#ifdef __LARGE__
+# define LARGE 1
+#endif
+#ifdef __HUGE__
+# define HUGE 1
+#endif
+
+#include <dos.h>
+
+/* Information about the current video state */
+struct PDC_video_state
+{
+    /* Information about the current video mode: */
+    unsigned short scrn_mode;
+    bool linear_buffer;
+    unsigned short video_width;  /* Width of graphics mode in pixels */
+    unsigned short video_height; /* Height of graphics mode in pixels */
+    unsigned short bytes_per_line; /* Bytes per raster line */
+    /* Location of the frame buffer in memory */
+    unsigned window[2];
+    unsigned offset[2];
+    unsigned long window_size;
+    /* Window used to read and write */
+    unsigned char read_win;
+    unsigned char write_win;
+
+    unsigned long font_addr; /* Address of font in ROM */
+
+    /* Cursor state */
+    bool cursor_visible;
+    int cursor_row;
+    int cursor_col;
+    unsigned char cursor_start;
+    unsigned char cursor_end;
+
+    short pdc_curstoreal[16];
+
+#if 0
+    int pdc_adapter;         /* screen type */
+    int pdc_scrnmode;        /* default screen mode */
+    int pdc_font;            /* default font size */
+    bool pdc_direct_video;   /* allow direct screen memory writes */
+    bool pdc_bogus_adapter;  /* TRUE if adapter has insane values */
+    unsigned pdc_video_seg;  /* video base segment */
+    unsigned pdc_video_ofs;  /* video base offset */
+
+    bool graphics_mode;      /* TRUE if operating in a graphics mode */
+    unsigned video_width;    /* Width of graphics mode in pixels */
+    unsigned video_height;   /* Height of graphics mode in pixels */
+#endif
+};
+extern struct PDC_video_state PDC_state;
+
+extern void PDC_private_cursor_off(void);
+extern void PDC_private_cursor_on(int row, int col);
+
+#ifdef __DJGPP__        /* Note: works only in plain DOS... */
+# if DJGPP == 2
+#  define _FAR_POINTER(s,o) ((((int)(s)) << 4) + ((int)(o)))
+# else
+#  define _FAR_POINTER(s,o) (0xe0000000 + (((int)(s)) << 4) + ((int)(o)))
+# endif
+# define _FP_SEGMENT(p)     (unsigned short)((((long)p) >> 4) & 0xffff)
+#else
+# ifdef __TURBOC__
+#  define _FAR_POINTER(s,o) MK_FP(s,o)
+# else
+#  if defined(__WATCOMC__) && defined(__FLAT__)
+#   define _FAR_POINTER(s,o) ((((int)(s)) << 4) + ((int)(o)))
+#  else
+#   define _FAR_POINTER(s,o) (((long)s << 16) | (long)o)
+#  endif
+# endif
+# define _FP_SEGMENT(p)     (unsigned short)(((long)p) >> 4)
+#endif
+#define _FP_OFFSET(p)       ((unsigned short)p & 0x000f)
+
+#ifdef __DJGPP__
+# include <sys/movedata.h>
+unsigned char getdosmembyte(int offs);
+unsigned short getdosmemword(int offs);
+unsigned long getdosmemdword(int offs);
+void setdosmembyte(int offs, unsigned char b);
+void setdosmemword(int offs, unsigned short w);
+#else
+# if SMALL || MEDIUM
+#  define PDC_FAR far
+# else
+#  define PDC_FAR
+# endif
+# define getdosmembyte(offs) \
+    (*((unsigned char PDC_FAR *) _FAR_POINTER(0,offs)))
+# define getdosmemword(offs) \
+    (*((unsigned short PDC_FAR *) _FAR_POINTER(0,offs)))
+# define getdosmemdword(offs) \
+    (*((unsigned long PDC_FAR *) _FAR_POINTER(0,offs)))
+# define setdosmembyte(offs,x) \
+    (*((unsigned char PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+# define setdosmemword(offs,x) \
+    (*((unsigned short PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+#endif
+
+#if defined(__WATCOMC__) && defined(__386__)
+
+typedef union
+{
+    struct
+    {
+        unsigned long edi, esi, ebp, res, ebx, edx, ecx, eax;
+    } d;
+
+    struct
+    {
+        unsigned short di, di_hi, si, si_hi, bp, bp_hi, res, res_hi,
+                       bx, bx_hi, dx, dx_hi, cx, cx_hi, ax, ax_hi,
+                       flags, es, ds, fs, gs, ip, cs, sp, ss;
+    } w;
+
+    struct
+    {
+        unsigned char edi[4], esi[4], ebp[4], res[4],
+                      bl, bh, ebx_b2, ebx_b3, dl, dh, edx_b2, edx_b3,
+                      cl, ch, ecx_b2, ecx_b3, al, ah, eax_b2, eax_b3;
+    } h;
+} pdc_dpmi_regs;
+
+void PDC_dpmi_int(int, pdc_dpmi_regs *);
+
+#endif
+
+#ifdef __DJGPP__
+# include <dpmi.h>
+# define PDCREGS __dpmi_regs
+# define PDCINT(vector, regs) __dpmi_int(vector, &regs)
+#else
+# ifdef __WATCOMC__
+#  ifdef __386__
+#   define PDCREGS pdc_dpmi_regs
+#   define PDCINT(vector, regs) PDC_dpmi_int(vector, &regs)
+#  else
+#   define PDCREGS union REGPACK
+#   define PDCINT(vector, regs) intr(vector, &regs)
+#  endif
+# else
+#  define PDCREGS union REGS
+#  define PDCINT(vector, regs) int86(vector, &regs, &regs)
+# endif
+#endif
+
+/* Wide registers in REGS: w or x? */
+
+#ifdef __WATCOMC__
+# define W w
+#else
+# define W x
+#endif
+
+/* Monitor (terminal) type information */
+
+enum
+{
+    _NONE, _MDA, _CGA,
+    _EGACOLOR = 0x04, _EGAMONO,
+    _VGACOLOR = 0x07, _VGAMONO,
+    _MCGACOLOR = 0x0a, _MCGAMONO,
+    _MDS_GENIUS = 0x30
+};
+
+/* Text-mode font size information */
+
+enum
+{
+    _FONT8 = 8,
+    _FONT14 = 14,
+    _FONT15,    /* GENIUS */
+    _FONT16
+};

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -47,7 +47,8 @@ struct PDC_video_state
 {
     /* Information about the current video mode: */
     unsigned short scrn_mode;
-    bool linear_buffer;
+    int linear_sel;
+    unsigned long linear_addr;
     unsigned char bits_per_pixel;
     unsigned short video_width;  /* Width of graphics mode in pixels */
     unsigned short video_height; /* Height of graphics mode in pixels */

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -85,6 +85,7 @@ extern void PDC_private_cursor_off(void);
 extern void PDC_private_cursor_on(int row, int col);
 
 #ifdef __DJGPP__        /* Note: works only in plain DOS... */
+# define PDC_FLAT 1
 # if DJGPP == 2
 #  define _FAR_POINTER(s,o) ((((int)(s)) << 4) + ((int)(o)))
 # else
@@ -96,6 +97,7 @@ extern void PDC_private_cursor_on(int row, int col);
 #  define _FAR_POINTER(s,o) MK_FP(s,o)
 # else
 #  if defined(__WATCOMC__) && defined(__FLAT__)
+#   define PDC_FLAT 1
 #   define _FAR_POINTER(s,o) ((((int)(s)) << 4) + ((int)(o)))
 #  else
 #   define _FAR_POINTER(s,o) (((long)s << 16) | (long)o)

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -122,17 +122,17 @@ void setdosmemdword(int offs, unsigned long d);
 #  define PDC_FAR
 # endif
 # define getdosmembyte(offs) \
-    (*((unsigned char PDC_FAR *) _FAR_POINTER(0,offs)))
+    (*((unsigned char PDC_FAR *) (offs)))
 # define getdosmemword(offs) \
-    (*((unsigned short PDC_FAR *) _FAR_POINTER(0,offs)))
+    (*((unsigned short PDC_FAR *) (offs)))
 # define getdosmemdword(offs) \
-    (*((unsigned long PDC_FAR *) _FAR_POINTER(0,offs)))
+    (*((unsigned long PDC_FAR *) (offs)))
 # define setdosmembyte(offs,x) \
-    (*((unsigned char PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+    (*((unsigned char PDC_FAR *) (offs)) = (x))
 # define setdosmemword(offs,x) \
-    (*((unsigned short PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+    (*((unsigned short PDC_FAR *) (offs)) = (x))
 # define setdosmemdword(offs,x) \
-    (*((unsigned long PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+    (*((unsigned long PDC_FAR *) (offs)) = (x))
 #endif
 
 #if defined(__WATCOMC__) && defined(__386__)

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -40,6 +40,7 @@
 struct PDC_color
 {
     short r, g, b;
+    unsigned long mapped;
 };
 
 struct PDC_video_state
@@ -59,6 +60,13 @@ struct PDC_video_state
     /* Window used to read and write */
     unsigned char read_win;
     unsigned char write_win;
+    /* Color mappings */
+    unsigned char red_max;
+    unsigned char red_pos;
+    unsigned char green_max;
+    unsigned char green_pos;
+    unsigned char blue_max;
+    unsigned char blue_pos;
 
     unsigned long font_addr; /* Address of font in ROM */
 
@@ -104,6 +112,7 @@ unsigned short getdosmemword(int offs);
 unsigned long getdosmemdword(int offs);
 void setdosmembyte(int offs, unsigned char b);
 void setdosmemword(int offs, unsigned short w);
+void setdosmemdword(int offs, unsigned long d);
 #else
 # if SMALL || MEDIUM
 #  define PDC_FAR far
@@ -120,6 +129,8 @@ void setdosmemword(int offs, unsigned short w);
     (*((unsigned char PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
 # define setdosmemword(offs,x) \
     (*((unsigned short PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
+# define setdosmemdword(offs,x) \
+    (*((unsigned long PDC_FAR *) _FAR_POINTER(0,offs)) = (x))
 #endif
 
 #if defined(__WATCOMC__) && defined(__386__)

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -37,11 +37,17 @@
 #include <dos.h>
 
 /* Information about the current video state */
+struct PDC_color
+{
+    short r, g, b;
+};
+
 struct PDC_video_state
 {
     /* Information about the current video mode: */
     unsigned short scrn_mode;
     bool linear_buffer;
+    unsigned char bits_per_pixel;
     unsigned short video_width;  /* Width of graphics mode in pixels */
     unsigned short video_height; /* Height of graphics mode in pixels */
     unsigned short bytes_per_line; /* Bytes per raster line */
@@ -63,7 +69,7 @@ struct PDC_video_state
     unsigned char cursor_start;
     unsigned char cursor_end;
 
-    short pdc_curstoreal[16];
+    struct PDC_color colors[PDC_MAXCOL];
 };
 extern struct PDC_video_state PDC_state;
 

--- a/dosvga/pdcdos.h
+++ b/dosvga/pdcdos.h
@@ -46,9 +46,10 @@ struct PDC_video_state
     unsigned short video_height; /* Height of graphics mode in pixels */
     unsigned short bytes_per_line; /* Bytes per raster line */
     /* Location of the frame buffer in memory */
-    unsigned window[2];
-    unsigned offset[2];
+    unsigned short window[2];
+    unsigned long offset[2];
     unsigned long window_size;
+    unsigned window_gran;
     /* Window used to read and write */
     unsigned char read_win;
     unsigned char write_win;
@@ -63,20 +64,6 @@ struct PDC_video_state
     unsigned char cursor_end;
 
     short pdc_curstoreal[16];
-
-#if 0
-    int pdc_adapter;         /* screen type */
-    int pdc_scrnmode;        /* default screen mode */
-    int pdc_font;            /* default font size */
-    bool pdc_direct_video;   /* allow direct screen memory writes */
-    bool pdc_bogus_adapter;  /* TRUE if adapter has insane values */
-    unsigned pdc_video_seg;  /* video base segment */
-    unsigned pdc_video_ofs;  /* video base offset */
-
-    bool graphics_mode;      /* TRUE if operating in a graphics mode */
-    unsigned video_width;    /* Width of graphics mode in pixels */
-    unsigned video_height;   /* Height of graphics mode in pixels */
-#endif
 };
 extern struct PDC_video_state PDC_state;
 

--- a/dosvga/pdcgetsc.c
+++ b/dosvga/pdcgetsc.c
@@ -1,0 +1,47 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+#include <stdlib.h>
+
+/* return width of screen/viewport */
+
+int PDC_get_columns(void)
+{
+    int cols;
+
+    PDC_LOG(("PDC_get_columns() - called\n"));
+
+    cols = PDC_state.video_width / 8;
+
+    PDC_LOG(("PDC_get_columns() - returned: cols %d\n", cols));
+
+    return cols;
+}
+
+/* get the cursor size/shape */
+
+int PDC_get_cursor_mode(void)
+{
+    PDC_LOG(("PDC_get_cursor_mode() - called\n"));
+
+    int start = _FONT16*3/4;
+    int end   = _FONT16-1;
+
+    return (start << 4) | end;
+}
+
+/* return number of screen rows */
+
+int PDC_get_rows(void)
+{
+    int rows;
+
+    PDC_LOG(("PDC_get_rows() - called\n"));
+
+    rows = PDC_state.video_height / _FONT16;
+
+    PDC_LOG(("PDC_get_rows() - returned: rows %d\n", rows));
+
+    return rows;
+}

--- a/dosvga/pdcgetsc.c
+++ b/dosvga/pdcgetsc.c
@@ -23,10 +23,10 @@ int PDC_get_columns(void)
 
 int PDC_get_cursor_mode(void)
 {
-    PDC_LOG(("PDC_get_cursor_mode() - called\n"));
-
     int start = _FONT16*3/4;
     int end   = _FONT16-1;
+
+    PDC_LOG(("PDC_get_cursor_mode() - called\n"));
 
     return (start << 8) | end;
 }

--- a/dosvga/pdcgetsc.c
+++ b/dosvga/pdcgetsc.c
@@ -28,7 +28,7 @@ int PDC_get_cursor_mode(void)
     int start = _FONT16*3/4;
     int end   = _FONT16-1;
 
-    return (start << 4) | end;
+    return (start << 8) | end;
 }
 
 /* return number of screen rows */

--- a/dosvga/pdckbd.c
+++ b/dosvga/pdckbd.c
@@ -1,0 +1,478 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+#ifdef __DJGPP__
+# include <fcntl.h>
+# include <io.h>
+# include <signal.h>
+#endif
+
+/************************************************************************
+ *    Table for key code translation of function keys in keypad mode    *
+ *    These values are for strict IBM keyboard compatibles only         *
+ ************************************************************************/
+
+static short key_table[] =
+{
+    -1,             ALT_ESC,        -1,             0,
+    -1,             -1,             -1,             -1,
+    -1,             -1,             -1,             -1,
+    -1,             -1,             ALT_BKSP,       KEY_BTAB,
+    ALT_Q,          ALT_W,          ALT_E,          ALT_R,
+    ALT_T,          ALT_Y,          ALT_U,          ALT_I,
+    ALT_O,          ALT_P,          ALT_LBRACKET,   ALT_RBRACKET,
+    ALT_ENTER,      -1,             ALT_A,          ALT_S,
+    ALT_D,          ALT_F,          ALT_G,          ALT_H,
+    ALT_J,          ALT_K,          ALT_L,          ALT_SEMICOLON,
+    ALT_FQUOTE,     ALT_BQUOTE,     -1,             ALT_BSLASH,
+    ALT_Z,          ALT_X,          ALT_C,          ALT_V,
+    ALT_B,          ALT_N,          ALT_M,          ALT_COMMA,
+    ALT_STOP,       ALT_FSLASH,     -1,             ALT_PADSTAR,
+    -1,             -1,             -1,             KEY_F(1),
+    KEY_F(2),       KEY_F(3),       KEY_F(4),       KEY_F(5),
+    KEY_F(6),       KEY_F(7),       KEY_F(8),       KEY_F(9),
+    KEY_F(10),      -1,             -1,             KEY_HOME,
+    KEY_UP,         KEY_PPAGE,      ALT_PADMINUS,   KEY_LEFT,
+    KEY_B2,         KEY_RIGHT,      ALT_PADPLUS,    KEY_END,
+    KEY_DOWN,       KEY_NPAGE,      KEY_IC,         KEY_DC,
+    KEY_F(13),      KEY_F(14),      KEY_F(15),      KEY_F(16),
+    KEY_F(17),      KEY_F(18),      KEY_F(19),      KEY_F(20),
+    KEY_F(21),      KEY_F(22),      KEY_F(25),      KEY_F(26),
+    KEY_F(27),      KEY_F(28),      KEY_F(29),      KEY_F(30),
+    KEY_F(31),      KEY_F(32),      KEY_F(33),      KEY_F(34),
+    KEY_F(37),      KEY_F(38),      KEY_F(39),      KEY_F(40),
+    KEY_F(41),      KEY_F(42),      KEY_F(43),      KEY_F(44),
+    KEY_F(45),      KEY_F(46),      -1,             CTL_LEFT,
+    CTL_RIGHT,      CTL_END,        CTL_PGDN,       CTL_HOME,
+    ALT_1,          ALT_2,          ALT_3,          ALT_4,
+    ALT_5,          ALT_6,          ALT_7,          ALT_8,
+    ALT_9,          ALT_0,          ALT_MINUS,      ALT_EQUAL,
+    CTL_PGUP,       KEY_F(11),      KEY_F(12),      KEY_F(23),
+    KEY_F(24),      KEY_F(35),      KEY_F(36),      KEY_F(47),
+    KEY_F(48),      CTL_UP,         CTL_PADMINUS,   CTL_PADCENTER,
+    CTL_PADPLUS,    CTL_DOWN,       CTL_INS,        CTL_DEL,
+    CTL_TAB,        CTL_PADSLASH,   CTL_PADSTAR,    ALT_HOME,
+    ALT_UP,         ALT_PGUP,       -1,             ALT_LEFT,
+    -1,             ALT_RIGHT,      -1,             ALT_END,
+    ALT_DOWN,       ALT_PGDN,       ALT_INS,        ALT_DEL,
+    ALT_PADSLASH,   ALT_TAB,        ALT_PADENTER,   -1
+};
+
+static struct {unsigned short pressed, released;} button[3];
+
+static bool mouse_avail = FALSE, mouse_vis = FALSE, mouse_moved = FALSE,
+            mouse_button = FALSE, key_pressed = FALSE;
+
+static unsigned char mouse_scroll = 0;
+static PDCREGS ms_regs, old_ms;
+static unsigned short shift_status, old_shift = 0;
+static unsigned char keyboard_function = 0xff, shift_function = 0xff,
+                     check_function = 0xff;
+
+static const unsigned short button_map[3] = {0, 2, 1};
+
+void PDC_set_keyboard_binary(bool on)
+{
+    PDC_LOG(("PDC_set_keyboard_binary() - called\n"));
+
+#ifdef __DJGPP__
+    setmode(fileno(stdin), on ? O_BINARY : O_TEXT);
+    signal(SIGINT, on ? SIG_IGN : SIG_DFL);
+#endif
+}
+
+/* check if a key or mouse event is waiting */
+
+bool PDC_check_key(void)
+{
+    PDCREGS regs;
+
+    if (shift_function == 0xff)
+    {
+        int scan;
+
+        /* get shift status for all keyboards */
+
+        regs.h.ah = 0x02;
+        PDCINT(0x16, regs);
+        scan = regs.h.al;
+
+        /* get shift status for enhanced keyboards */
+
+        regs.h.ah = 0x12;
+        PDCINT(0x16, regs);
+
+        if (scan == regs.h.al && getdosmembyte(0x496) == 0x10)
+        {
+            keyboard_function = 0x10;
+            check_function = 0x11;
+            shift_function = 0x12;
+        }
+        else
+        {
+            keyboard_function = 0;
+            check_function = 1;
+            shift_function = 2;
+        }
+    }
+
+    regs.h.ah = shift_function;
+    PDCINT(0x16, regs);
+
+    shift_status = regs.W.ax;
+
+    if (mouse_vis)
+    {
+        unsigned short i;
+
+        ms_regs.W.ax = 3;
+        PDCINT(0x33, ms_regs);
+
+        mouse_button = FALSE;
+
+        for (i = 0; i < 3; i++)
+        {
+            regs.W.ax = 6;
+            regs.W.bx = button_map[i];
+            PDCINT(0x33, regs);
+            button[i].released = regs.W.bx;
+            if (regs.W.bx)
+            {
+                ms_regs.W.cx = regs.W.cx;
+                ms_regs.W.dx = regs.W.dx;
+                mouse_button = TRUE;
+            }
+
+            regs.W.ax = 5;
+            regs.W.bx = button_map[i];
+            PDCINT(0x33, regs);
+            button[i].pressed = regs.W.bx;
+            if (regs.W.bx)
+            {
+                ms_regs.W.cx = regs.W.cx;
+                ms_regs.W.dx = regs.W.dx;
+                mouse_button = TRUE;
+            }
+        }
+
+        mouse_scroll = ms_regs.h.bh;
+
+        mouse_moved = !mouse_button && ms_regs.h.bl &&
+                       ms_regs.h.bl == old_ms.h.bl &&
+                    (((ms_regs.W.cx ^ old_ms.W.cx) >> 3) ||
+                     ((ms_regs.W.dx / _FONT16) ^ (old_ms.W.dx / _FONT16)));
+
+        if (mouse_scroll || mouse_button || mouse_moved)
+            return TRUE;
+    }
+
+    if (old_shift && !shift_status)     /* modifier released */
+    {
+        if (!key_pressed && SP->return_key_modifiers)
+            return TRUE;
+    }
+    else if (!old_shift && shift_status)    /* modifier pressed */
+        key_pressed = FALSE;
+
+    old_shift = shift_status;
+
+    regs.h.ah = check_function;
+    PDCINT(0x16, regs);
+
+    return !(regs.W.flags & 64);
+}
+
+static int _process_mouse_events(void)
+{
+    int i;
+    short shift_flags = 0;
+
+    memset(&SP->mouse_status, 0, sizeof(SP->mouse_status));
+
+    key_pressed = TRUE;
+    old_shift = shift_status;
+    SP->key_code = TRUE;
+
+    /* Set shift modifiers */
+
+    if (shift_status & 3)
+        shift_flags |= BUTTON_SHIFT;
+
+    if (shift_status & 4)
+        shift_flags |= BUTTON_CONTROL;
+
+    if (shift_status & 8)
+        shift_flags |= BUTTON_ALT;
+
+    /* Scroll wheel support for CuteMouse */
+
+    if (mouse_scroll)
+    {
+        SP->mouse_status.changes = mouse_scroll & 0x80 ?
+            PDC_MOUSE_WHEEL_UP : PDC_MOUSE_WHEEL_DOWN;
+
+        SP->mouse_status.x = -1;
+        SP->mouse_status.y = -1;
+
+        return KEY_MOUSE;
+    }
+
+    if (mouse_moved)
+    {
+        SP->mouse_status.changes = PDC_MOUSE_MOVED;
+
+        for (i = 0; i < 3; i++)
+        {
+            if (ms_regs.h.bl & (1 << button_map[i]))
+            {
+                SP->mouse_status.button[i] = BUTTON_MOVED | shift_flags;
+                SP->mouse_status.changes |= (1 << i);
+            }
+        }
+    }
+    else    /* button event */
+    {
+        for (i = 0; i < 3; i++)
+        {
+            if (button[i].pressed)
+            {
+                /* Check for a click -- a PRESS followed
+                   immediately by a release */
+
+                if (!button[i].released)
+                {
+                    if (SP->mouse_wait)
+                    {
+                        PDCREGS regs;
+
+                        napms(SP->mouse_wait);
+
+                        regs.W.ax = 6;
+                        regs.W.bx = button_map[i];
+                        PDCINT(0x33, regs);
+
+                        SP->mouse_status.button[i] = regs.W.bx ?
+                            BUTTON_CLICKED : BUTTON_PRESSED;
+                    }
+                    else
+                        SP->mouse_status.button[i] = BUTTON_PRESSED;
+                }
+                else
+                    SP->mouse_status.button[i] = BUTTON_CLICKED;
+            }
+
+            if (button[i].pressed || button[i].released)
+            {
+                SP->mouse_status.button[i] |= shift_flags;
+                SP->mouse_status.changes |= (1 << i);
+            }
+        }
+    }
+
+    SP->mouse_status.x = ms_regs.W.cx >> 3;
+    SP->mouse_status.y = ms_regs.W.dx / _FONT16;
+
+    old_ms = ms_regs;
+
+    return KEY_MOUSE;
+}
+
+/* return the next available key or mouse event */
+
+int PDC_get_key(void)
+{
+    PDCREGS regs;
+    int key, scan;
+
+    SP->key_modifiers = 0;
+
+    if (mouse_vis && (mouse_scroll || mouse_button || mouse_moved))
+        return _process_mouse_events();
+
+    /* Return modifiers as keys? */
+
+    if (old_shift && !shift_status)
+    {
+        key = -1;
+
+        if (old_shift & 1)
+            key = KEY_SHIFT_R;
+
+        if (old_shift & 2)
+            key = KEY_SHIFT_L;
+
+        if (shift_function == 0x12)
+        {
+            if (old_shift & 0x400)
+                key = KEY_CONTROL_R;
+
+            if (old_shift & 0x100)
+                key = KEY_CONTROL_L;
+
+            if (old_shift & 0x800)
+                key = KEY_ALT_R;
+
+            if (old_shift & 0x200)
+                key = KEY_ALT_L;
+        }
+        else
+        {
+            if (old_shift & 4)
+                key = KEY_CONTROL_R;
+
+            if (old_shift & 8)
+                key = KEY_ALT_R;
+        }
+
+        key_pressed = FALSE;
+        old_shift = shift_status;
+
+        SP->key_code = TRUE;
+        return key;
+    }
+
+    regs.h.ah = keyboard_function;
+    PDCINT(0x16, regs);
+    key = regs.h.al;
+    scan = regs.h.ah;
+
+    if (shift_status & 3)
+        SP->key_modifiers |= PDC_KEY_MODIFIER_SHIFT;
+
+    if (shift_status & 4)
+        SP->key_modifiers |= PDC_KEY_MODIFIER_CONTROL;
+
+    if (shift_status & 8)
+        SP->key_modifiers |= PDC_KEY_MODIFIER_ALT;
+
+    if (shift_status & 0x20)
+        SP->key_modifiers |= PDC_KEY_MODIFIER_NUMLOCK;
+
+    if (scan == 0x1c && key == 0x0a)    /* ^Enter */
+        key = CTL_ENTER;
+    else if (scan == 0xe0 && key == 0x0d)   /* PadEnter */
+        key = PADENTER;
+    else if (scan == 0xe0 && key == 0x0a)   /* ^PadEnter */
+        key = CTL_PADENTER;
+    else if (scan == 0x37 && key == 0x2a)   /* Star */
+        key = PADSTAR;
+    else if (scan == 0x4a && key == 0x2d)   /* Minus */
+        key = PADMINUS;
+    else if (scan == 0x4e && key == 0x2b)   /* Plus */
+        key = PADPLUS;
+    else if (scan == 0xe0 && key == 0x2f)   /* Slash */
+        key = PADSLASH;
+    else if (key == 0x00 || (key == 0xe0 && scan > 53 && scan != 86))
+        key = (scan > 0xa7) ? -1 : key_table[scan];
+
+    if (shift_status & 3)
+    {
+        switch (key)
+        {
+        case KEY_HOME:  /* Shift Home */
+            key = KEY_SHOME;
+            break;
+        case KEY_UP:    /* Shift Up */
+            key = KEY_SUP;
+            break;
+        case KEY_PPAGE: /* Shift PgUp */
+            key = KEY_SPREVIOUS;
+            break;
+        case KEY_LEFT:  /* Shift Left */
+            key = KEY_SLEFT;
+            break;
+        case KEY_RIGHT: /* Shift Right */
+            key = KEY_SRIGHT;
+            break;
+        case KEY_END:   /* Shift End */
+            key = KEY_SEND;
+            break;
+        case KEY_DOWN:  /* Shift Down */
+            key = KEY_SDOWN;
+            break;
+        case KEY_NPAGE: /* Shift PgDn */
+            key = KEY_SNEXT;
+            break;
+        case KEY_IC:    /* Shift Ins */
+            key = KEY_SIC;
+            break;
+        case KEY_DC:    /* Shift Del */
+            key = KEY_SDC;
+        }
+    }
+
+    key_pressed = TRUE;
+    SP->key_code = ((unsigned)key >= 256);
+
+    return key;
+}
+
+/* discard any pending keyboard or mouse input -- this is the core
+   routine for flushinp() */
+
+void PDC_flushinp(void)
+{
+    PDC_LOG(("PDC_flushinp() - called\n"));
+
+    /* Force the BIOS keyboard buffer head and tail pointers to be
+       the same...  Real nasty trick... */
+
+    setdosmemword(0x41a, getdosmemword(0x41c));
+}
+
+bool PDC_has_mouse(void)
+{
+    PDCREGS regs;
+
+    if (!mouse_avail)
+    {
+        regs.W.ax = 0;
+        PDCINT(0x33, regs);
+
+        mouse_avail = !!(regs.W.ax);
+    }
+
+    return mouse_avail;
+}
+
+int PDC_mouse_set(void)
+{
+    PDCREGS regs;
+    unsigned long mbe = SP->_trap_mbe;
+
+    if (mbe && !mouse_avail)
+        mouse_avail = PDC_has_mouse();
+
+    if (mbe)
+    {
+        if (mouse_avail && !mouse_vis)
+        {
+            memset(&old_ms, 0, sizeof(old_ms));
+
+            regs.W.ax = 1;
+            PDCINT(0x33, regs);
+
+            mouse_vis = TRUE;
+        }
+    }
+    else
+    {
+        if (mouse_avail && mouse_vis)
+        {
+            regs.W.ax = 2;
+            PDCINT(0x33, regs);
+
+            mouse_vis = FALSE;
+        }
+    }
+
+    return (mouse_avail || !mbe) ? OK : ERR;
+}
+
+int PDC_modifiers_set(void)
+{
+    key_pressed = FALSE;
+
+    return OK;
+}

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -115,7 +115,16 @@ void PDC_scr_free(void)
 
 int PDC_scr_open(void)
 {
+    PDCREGS regs;
+
     PDC_LOG(("PDC_scr_open() - called\n"));
+
+    /* Check for VGA and bail out if we don't find one */
+    memset(&regs, 0, sizeof(regs));
+    regs.W.ax = 0x1A00;
+    PDCINT(0x10, regs);
+    if (regs.h.bl != 8)
+        return ERR;
 
     SP = calloc(1, sizeof(SCREEN));
 

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -427,7 +427,7 @@ static unsigned _find_mode(
     selected_size = (rows == 0 && cols == 0) ? 0 : 0xFFFFFFFF;
     selected_bits = 0;
 
-    if (rows <= 30 && cols <= 80)
+    if ((rows <= 30 && cols <= 80) && !(rows == 0 && cols == 0))
     {
         /* Set up a ModeInfoBlock for mode 0x0012 */
         selected_mode = 0x0012;
@@ -507,9 +507,9 @@ static unsigned _find_mode(
            columns. */
         if (mode_info0.BitsPerPixel < selected_bits)
             continue;
+        new_size = (unsigned long)new_rows * new_cols;
         if (mode_info0.BitsPerPixel == selected_bits)
         {
-            new_size = (unsigned long)new_rows * new_cols;
             if (rows == 0 && cols == 0)
             {
                 if (new_size <= selected_size)

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -201,7 +201,6 @@ void PDC_save_screen_mode(int i)
 
 static short _egapal(short color)
 {
-    /* TODO: is this why I don't see output? */
     PDCREGS regs;
 
     regs.W.ax = 0x1007;
@@ -225,7 +224,6 @@ int PDC_color_content(short color, short *red, short *green, short *blue)
 
     /* Read single DAC register */
     /* TODO: support VESA modes */
-    /* TODO: is this why I don't see output? */
 
     regs.W.ax = 0x1015;
     regs.h.bl = _egapal(color);
@@ -253,7 +251,6 @@ int PDC_init_color(short color, short red, short green, short blue)
 
     /* Set single DAC register */
     /* TODO: support VESA modes */
-    /* TODO: is this why I don't see output? */
 
     regs.W.ax = 0x1010;
     regs.W.bx = _egapal(color);

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -271,9 +271,9 @@ int PDC_init_color(short color, short red, short green, short blue)
             seg = __dpmi_allocate_dos_memory(1, &sel);
             if (seg < 0)
                 return ERR;
-            table[0] = DIVROUND((unsigned)red * 63, 1000);
+            table[0] = DIVROUND((unsigned)blue * 63, 1000);
             table[1] = DIVROUND((unsigned)green * 63, 1000);
-            table[2] = DIVROUND((unsigned)blue * 63, 1000);
+            table[2] = DIVROUND((unsigned)red * 63, 1000);
             table[3] = 0;
             dosmemput(table, sizeof(table), seg * 16L);
             memset(&d_regs, 0, sizeof(d_regs));

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* TODO: support 8 bit palette registers if available */
-
 struct PDC_video_state PDC_state;
 
 static int saved_scrnmode[3];
@@ -231,6 +229,22 @@ static void _load_palette(void)
             regs.W.ax = 0x1000;
             regs.W.bx = i * 0x0101;
             PDCINT(0x10, regs);
+        }
+
+        /* Set 8 bit DACs if available */
+        /* This doesn't seem to work with 4 bit color */
+        if (PDC_state.bits_per_pixel == 8)
+        {
+            unsigned dacmax;
+
+            memset(&regs, 0, sizeof(regs));
+            regs.W.ax = 0x4F08;
+            regs.W.bx = 0x0800;
+            PDCINT(0x10, regs);
+            dacmax = (regs.W.ax == 0x004F) ? (1 << regs.h.bh) - 1 : 63;
+            PDC_state.red_max = dacmax;
+            PDC_state.green_max = dacmax;
+            PDC_state.blue_max = dacmax;
         }
 
         /* Load the DAC registers from the current palette */

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -1,0 +1,264 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* TODO: support 8 bit palette registers if available */
+/* TODO: support modes with more than 4 bits per pixel */
+
+struct PDC_video_state PDC_state;
+
+static short realtocurs[16] =
+{
+    COLOR_BLACK, COLOR_BLUE, COLOR_GREEN, COLOR_CYAN, COLOR_RED,
+    COLOR_MAGENTA, COLOR_YELLOW, COLOR_WHITE, COLOR_BLACK + 8,
+    COLOR_BLUE + 8, COLOR_GREEN + 8, COLOR_CYAN + 8, COLOR_RED + 8,
+    COLOR_MAGENTA + 8, COLOR_YELLOW + 8, COLOR_WHITE + 8
+};
+
+static int saved_scrnmode[3];
+
+/* _get_font_address() -- return the address of the font in ROM */
+static unsigned long _get_font_address(void)
+{
+    /* TODO: support compilers other than DJGPP */
+    unsigned ofs = getdosmemword(0x43 * 4 + 0);
+    unsigned seg = getdosmemword(0x43 * 4 + 2);
+    return ((unsigned long)seg << 4) + ofs;
+}
+
+/* _get_scrn_mode() - Return the current BIOS video mode */
+
+static int _get_scrn_mode(void)
+{
+    PDCREGS regs;
+
+    memset(&regs, 0, sizeof(regs));
+    regs.W.ax = 0x4F03;
+    PDCINT(0x10, regs);
+    if (regs.h.ah == 0) {
+        return (int)regs.W.bx;
+    }
+
+    regs.h.ah = 0x0f;
+    PDCINT(0x10, regs);
+
+    return (int)regs.h.al;
+}
+
+/* _set_scrn_mode() - Sets the BIOS Video Mode Number */
+
+static void _set_scrn_mode(int new_mode)
+{
+    PDCREGS regs;
+
+    memset(&regs, 0, sizeof(regs));
+    if (new_mode >= 0x100) {
+        regs.W.ax = 0x4F02;
+        regs.W.bx = new_mode;
+    } else {
+        regs.h.ah = 0;
+        regs.h.al = (unsigned char) new_mode;
+    }
+    PDCINT(0x10, regs);
+    PDC_state.scrn_mode = new_mode & 0x3FFF;
+
+    if (PDC_state.scrn_mode < 0x100)
+    {
+        PDC_state.linear_buffer = FALSE;
+        PDC_state.video_width = 640;
+        PDC_state.video_height = 400;
+        PDC_state.bytes_per_line = 80;
+        switch (PDC_state.scrn_mode)
+        {
+        case 0x0D:
+        case 0x0E:
+            PDC_state.video_height = 200;
+            break;
+
+        case 0x0F:
+        case 0x10:
+            PDC_state.video_height = 350;
+            break;
+
+        case 0x11:
+        case 0x12:
+            PDC_state.video_height = 480;
+            break;
+        }
+    }
+    else
+    {
+        /* TODO: support VESA modes */
+    }
+
+    PDC_state.font_addr = _get_font_address();
+    LINES = PDC_get_rows();
+    COLS = PDC_get_columns();
+    PDC_curs_set(1);
+}
+
+/* close the physical screen -- may restore the screen to its state
+   before PDC_scr_open(); miscellaneous cleanup */
+
+void PDC_scr_close(void)
+{
+    PDCREGS regs;
+
+    _set_scrn_mode(0x03);
+    memset(&regs, 0, sizeof(regs));
+    regs.W.ax = 0x1114;
+    regs.h.bl = 0x00;
+    PDCINT(0x10, regs);
+}
+
+void PDC_scr_free(void)
+{
+}
+
+/* open the physical screen -- miscellaneous initialization, may save
+   the existing screen for later restoration */
+
+int PDC_scr_open(void)
+{
+#if SMALL || MEDIUM
+    struct SREGS segregs;
+    int ds;
+#endif
+    int i;
+
+    PDC_LOG(("PDC_scr_open() - called\n"));
+
+    SP = calloc(1, sizeof(SCREEN));
+
+    if (!SP)
+        return ERR;
+
+    PDC_resize_screen(80, 25);
+    for (i = 0; i < 16; i++)
+        PDC_state.pdc_curstoreal[realtocurs[i]] = i;
+
+    SP->orig_attr = FALSE;
+
+    SP->mouse_wait = PDC_CLICK_PERIOD;
+    SP->audible = TRUE;
+
+    SP->mono = FALSE;
+    SP->termattrs = A_COLOR | A_REVERSE | A_UNDERLINE;
+
+    SP->_preserve = FALSE;
+
+    return OK;
+}
+
+/* the core of resize_term() */
+
+int PDC_resize_screen(int nlines, int ncols)
+{
+    PDC_LOG(("PDC_resize_screen() - called. Lines: %d Cols: %d\n",
+             nlines, ncols));
+
+    /* Trash the stored value of orig_cursor -- it's only good if the
+       video mode doesn't change */
+
+    SP->orig_cursor = 0x0607;
+
+    _set_scrn_mode(0x12);
+
+    return OK;
+}
+
+void PDC_reset_prog_mode(void)
+{
+        PDC_LOG(("PDC_reset_prog_mode() - called.\n"));
+}
+
+void PDC_reset_shell_mode(void)
+{
+        PDC_LOG(("PDC_reset_shell_mode() - called.\n"));
+}
+
+void PDC_restore_screen_mode(int i)
+{
+    if (i >= 0 && i <= 2)
+    {
+        _set_scrn_mode(saved_scrnmode[i]);
+    }
+}
+
+void PDC_save_screen_mode(int i)
+{
+    if (i >= 0 && i <= 2)
+    {
+        saved_scrnmode[i] = _get_scrn_mode();
+    }
+}
+
+/* _egapal() - Find the EGA palette value (0-63) for the color (0-15).
+   On VGA, this is an index into the DAC. */
+
+static short _egapal(short color)
+{
+    /* TODO: is this why I don't see output? */
+    PDCREGS regs;
+
+    regs.W.ax = 0x1007;
+    regs.h.bl = PDC_state.pdc_curstoreal[color];
+
+    PDCINT(0x10, regs);
+
+    return regs.h.bh;
+}
+
+bool PDC_can_change_color(void)
+{
+    return TRUE;
+}
+
+/* These are only valid when PDC_state.pdc_adapter == _VGACOLOR */
+
+int PDC_color_content(short color, short *red, short *green, short *blue)
+{
+    PDCREGS regs;
+
+    /* Read single DAC register */
+    /* TODO: support VESA modes */
+    /* TODO: is this why I don't see output? */
+
+    regs.W.ax = 0x1015;
+    regs.h.bl = _egapal(color);
+
+    PDCINT(0x10, regs);
+
+    /* Scale and store */
+
+    *red = DIVROUND((unsigned)(regs.h.dh) * 1000, 63);
+    *green = DIVROUND((unsigned)(regs.h.ch) * 1000, 63);
+    *blue = DIVROUND((unsigned)(regs.h.cl) * 1000, 63);
+
+    return OK;
+}
+
+int PDC_init_color(short color, short red, short green, short blue)
+{
+    PDCREGS regs;
+
+    /* Scale */
+
+    regs.h.dh = DIVROUND((unsigned)red * 63, 1000);
+    regs.h.ch = DIVROUND((unsigned)green * 63, 1000);
+    regs.h.cl = DIVROUND((unsigned)blue * 63, 1000);
+
+    /* Set single DAC register */
+    /* TODO: support VESA modes */
+    /* TODO: is this why I don't see output? */
+
+    regs.W.ax = 0x1010;
+    regs.W.bx = _egapal(color);
+
+    PDCINT(0x10, regs);
+
+    return OK;
+}

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -76,7 +76,6 @@ static void _set_scrn_mode(int new_mode)
     PDC_state.font_addr = _get_font_address();
     LINES = PDC_get_rows();
     COLS = PDC_get_columns();
-    PDC_curs_set(1);
 }
 
 /* close the physical screen -- may restore the screen to its state
@@ -139,12 +138,9 @@ int PDC_resize_screen(int nlines, int ncols)
     PDC_LOG(("PDC_resize_screen() - called. Lines: %d Cols: %d\n",
              nlines, ncols));
 
-    /* Trash the stored value of orig_cursor -- it's only good if the
-       video mode doesn't change */
-
-    SP->orig_cursor = 0x0607;
-
     _set_scrn_mode(_find_video_mode(nlines, ncols));
+    SP->orig_cursor = PDC_get_cursor_mode();
+    PDC_curs_set(SP->visibility);
 
     return OK;
 }

--- a/dosvga/pdcscrn.c
+++ b/dosvga/pdcscrn.c
@@ -1,6 +1,7 @@
 /* PDCurses */
 
 #include "pdcdos.h"
+#include "pdcvesa.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -19,6 +20,13 @@ static short realtocurs[16] =
 };
 
 static int saved_scrnmode[3];
+
+static int _get_mode_info(unsigned mode, struct ModeInfoBlock *mode_info);
+static unsigned _find_video_mode(int rows, int cols);
+static unsigned _find_mode(
+        struct ModeInfoBlock *mode_info,
+        unsigned long mode_addr,
+        int rows, int cols);
 
 /* _get_font_address() -- return the address of the font in ROM */
 static unsigned long _get_font_address(void)
@@ -65,35 +73,6 @@ static void _set_scrn_mode(int new_mode)
     PDCINT(0x10, regs);
     PDC_state.scrn_mode = new_mode & 0x3FFF;
 
-    if (PDC_state.scrn_mode < 0x100)
-    {
-        PDC_state.linear_buffer = FALSE;
-        PDC_state.video_width = 640;
-        PDC_state.video_height = 400;
-        PDC_state.bytes_per_line = 80;
-        switch (PDC_state.scrn_mode)
-        {
-        case 0x0D:
-        case 0x0E:
-            PDC_state.video_height = 200;
-            break;
-
-        case 0x0F:
-        case 0x10:
-            PDC_state.video_height = 350;
-            break;
-
-        case 0x11:
-        case 0x12:
-            PDC_state.video_height = 480;
-            break;
-        }
-    }
-    else
-    {
-        /* TODO: support VESA modes */
-    }
-
     PDC_state.font_addr = _get_font_address();
     LINES = PDC_get_rows();
     COLS = PDC_get_columns();
@@ -136,7 +115,7 @@ int PDC_scr_open(void)
     if (!SP)
         return ERR;
 
-    PDC_resize_screen(80, 25);
+    PDC_resize_screen(25, 80);
     for (i = 0; i < 16; i++)
         PDC_state.pdc_curstoreal[realtocurs[i]] = i;
 
@@ -165,7 +144,7 @@ int PDC_resize_screen(int nlines, int ncols)
 
     SP->orig_cursor = 0x0607;
 
-    _set_scrn_mode(0x12);
+    _set_scrn_mode(_find_video_mode(nlines, ncols));
 
     return OK;
 }
@@ -258,4 +237,319 @@ int PDC_init_color(short color, short red, short green, short blue)
     PDCINT(0x10, regs);
 
     return OK;
+}
+
+static unsigned _find_video_mode(int rows, int cols)
+{
+    int vbe_info_sel = -1; /* custodial */
+    int vbe_info_seg;
+    struct VbeInfoBlock vbe_info;
+    __dpmi_regs regs;
+    unsigned long mode_addr;
+    struct ModeInfoBlock mode_info;
+    unsigned vesa_mode;
+
+    /* Request VESA BIOS information */
+    vbe_info_seg = __dpmi_allocate_dos_memory(
+            (sizeof(vbe_info) + 15) / 16,
+            &vbe_info_sel);
+    if (vbe_info_seg < 0)
+        goto error;
+
+    memset(&vbe_info, 0, sizeof(vbe_info));
+    memcpy(vbe_info.VbeSignature, "VBE2", 4);
+    dosmemput(&vbe_info, sizeof(vbe_info), vbe_info_seg * 16L);
+
+	memset(&regs, 0, sizeof(regs));
+    regs.x.ax = 0x4F00;
+    regs.x.di = 0;
+    regs.x.es = vbe_info_seg;
+    __dpmi_int(0x10, &regs);
+
+    /* Check for successful completion of function: is VESA BIOS present? */
+    if (regs.x.ax != 0x004F)
+        goto error;
+    dosmemget(vbe_info_seg * 16L, sizeof(vbe_info), &vbe_info);
+    if (memcmp(vbe_info.VbeSignature, "VESA", 4) != 0)
+        goto error;
+
+    /* Get the address of the mode list */
+    /* The mode list may be within the DOS memory area allocated above.
+       That area must remain allocated and must not be rewritten until
+       we're done here. */
+    mode_addr = (vbe_info.VideoModePtr >> 16) * 16L
+              + (vbe_info.VideoModePtr & 0xFFFF);
+
+    /* Look for the best-fitting mode available */
+    vesa_mode = _find_mode(&mode_info, mode_addr, rows, cols);
+    if (vesa_mode == 0xFFFF)
+        vesa_mode = _find_mode(&mode_info, mode_addr, 0, 0);
+    if (vesa_mode == 0xFFFF)
+        goto error;
+
+    /* Set up frame buffer window */
+    if ((mode_info.WinAAttributes & 0x2) != 0)
+        PDC_state.read_win = 0; /* Read through Window A */
+    else if ((mode_info.WinBAttributes & 0x2) != 0)
+        PDC_state.read_win = 1; /* Read through Window B */
+    else
+        goto error; /* shouldn't happen */
+    if ((mode_info.WinAAttributes & 0x1) != 0)
+        PDC_state.write_win = 0; /* Write through Window A */
+    else if ((mode_info.WinBAttributes & 0x1) != 0)
+        PDC_state.write_win = 1; /* Write through Window B */
+    else
+        goto error; /* shouldn't happen */
+    PDC_state.window[0] = mode_info.WinASegment;
+    PDC_state.window[1] = mode_info.WinBSegment;
+    if (vesa_mode == 0x12)
+    {
+        PDC_state.offset[0] = 0;
+        PDC_state.offset[1] = 0;
+    }
+    else
+    {
+        PDC_state.offset[0] = 0xFFFFFFFF; /* offset is unknown */
+        PDC_state.offset[1] = 0xFFFFFFFF;
+    }
+    PDC_state.window_size = mode_info.WinSize * 1024L;
+    PDC_state.window_gran = mode_info.WinGranularity;
+    PDC_state.bytes_per_line = mode_info.BytesPerScanLine;
+    PDC_state.video_width = mode_info.XResolution;
+    PDC_state.video_height = mode_info.YResolution;
+
+    __dpmi_free_dos_memory(vbe_info_sel);
+    return vesa_mode;
+
+error:
+    /* If we can't access the VESA BIOS Extensions for any reason, return the
+       640x480 VGA mode */
+    if (vbe_info_sel != -1)
+        __dpmi_free_dos_memory(vbe_info_sel);
+
+    PDC_state.linear_buffer = FALSE;
+    PDC_state.video_width = 640;
+    PDC_state.video_height = 480;
+    PDC_state.bytes_per_line = 80;
+    PDC_state.read_win = 0;
+    PDC_state.write_win = 0;
+    PDC_state.window[0] = 0xA000;
+    PDC_state.window[1] = 0xA000;
+    PDC_state.offset[0] = 0;
+    PDC_state.offset[1] = 0;
+    PDC_state.window_size = (640/8) * 480;
+    PDC_state.window_gran = 1;
+
+    return 0x12;
+}
+
+static unsigned _find_mode(
+        struct ModeInfoBlock *mode_info,
+        unsigned long mode_addr,
+        int rows, int cols)
+{
+    unsigned selected_mode;
+    unsigned long selected_size;
+
+    selected_mode = 0xFFFF;
+    selected_size = (rows == 0 && cols == 0) ? 0 : 0xFFFFFFFF;
+
+    if (rows <= 30 && cols <= 80)
+    {
+        /* Set up a ModeInfoBlock for mode 0x0012 */
+        selected_mode = 0x0012;
+        selected_size = 80 * 30;
+        memset(mode_info, 0, sizeof(*mode_info));
+        mode_info->ModeAttributes = 0x1F;
+        mode_info->WinAAttributes = 0x07;
+        mode_info->WinBAttributes = 0x00;
+        mode_info->WinGranularity = 1;
+        mode_info->WinSize = 38;
+        mode_info->WinASegment = 0xA000;
+        mode_info->WinBSegment = 0;
+        mode_info->WinFuncPtr = 0;
+        mode_info->BytesPerScanLine = 80;
+        mode_info->XResolution = 640;
+        mode_info->YResolution = 480;
+        mode_info->NumberOfPlanes = 4;
+        mode_info->BitsPerPixel = 4;
+        mode_info->NumberOfBanks = 1;
+        mode_info->MemoryModel = 3;
+    }
+
+    while (1)
+    {
+        unsigned mode;
+        struct ModeInfoBlock mode_info0;
+        unsigned new_rows, new_cols;
+        unsigned long new_size;
+
+        mode = getdosmemword(mode_addr);
+        if (mode == 0xFFFF)
+            break;
+        mode_addr += 2;
+
+        /* Query the mode info; skip if not supported */
+        if (_get_mode_info(mode, &mode_info0) < 0)
+            continue;
+
+        /* Check that the mode is acceptable: */
+        /* Supported, graphics mode, color, VGA compatible */
+        if ((mode_info0.ModeAttributes & 0x79) != 0x19)
+            continue;
+        /* Bits per pixel and memory model are acceptable */
+        switch (mode_info0.BitsPerPixel)
+        {
+        case 4:
+            if (mode_info0.MemoryModel != 3) /* Planar */
+                continue;
+            if (mode_info0.NumberOfPlanes != 4)
+                continue;
+            break;
+        /* TODO: 8, 15, 16, 24 and 32 bits */
+
+        default:
+            continue;
+        }
+
+        /* At least as many rows and columns as requested */
+        new_cols = mode_info0.XResolution / 8;
+        new_rows = mode_info0.YResolution / _FONT16;
+        if (new_cols < cols || new_rows < rows)
+            continue;
+
+        /* If rows == 0 and cols == 0, select the largest available size;
+           otherwise, select the smallest that can hold that many rows and
+           columns */
+        new_size = (unsigned long)new_rows * new_cols;
+        if (rows == 0 && cols == 0)
+        {
+            if (new_size <= selected_size)
+                continue;
+        }
+        else
+        {
+            if (new_size >= selected_size)
+                continue;
+        }
+
+        /* Select this mode, pending discovery of a better one */
+        selected_mode = mode;
+        selected_size = new_size;
+        *mode_info = mode_info0;
+    }
+
+    return selected_mode;
+}
+
+static int _get_mode_info(unsigned mode, struct ModeInfoBlock *mode_info)
+{
+    struct OldModeInfo
+    {
+        unsigned mode;
+
+        unsigned short XResolution;    /* horizontal resolution in pixels or characters */
+        unsigned short YResolution;    /* vertical resolution in pixels or characters */
+        unsigned char  BitsPerPixel;   /* bits per pixel */
+    };
+    static const struct OldModeInfo old_mode_table[] =
+    {
+        { 0x0100,  640,  480,  4 },
+        { 0x0101,  640,  480,  8 },
+        { 0x0102,  800,  600,  4 },
+        { 0x0103,  800,  600,  8 },
+        { 0x0104, 1024,  768,  4 },
+        { 0x0105, 1024,  768,  8 },
+        { 0x0106, 1280, 1024,  4 },
+        { 0x0107, 1280, 1024,  8 },
+        { 0x010D,  320,  200, 15 },
+        { 0x010E,  320,  200, 16 },
+        { 0x010F,  320,  200, 24 },
+        { 0x0110,  640,  480, 15 },
+        { 0x0111,  640,  480, 16 },
+        { 0x0112,  640,  480, 24 },
+        { 0x0113,  800,  600, 15 },
+        { 0x0114,  800,  600, 16 },
+        { 0x0115,  800,  600, 24 },
+        { 0x0116, 1024,  768, 15 },
+        { 0x0117, 1024,  768, 16 },
+        { 0x0118, 1024,  768, 24 },
+        { 0x0119, 1280, 1024, 15 },
+        { 0x011A, 1280, 1024, 16 },
+        { 0x011B, 1280, 1024, 24 },
+        /* sentinel */
+        { 0, 0, 0, 0 }
+    };
+
+    int mode_info_sel = -1; /* custodial */
+    int mode_info_seg;
+    __dpmi_regs regs;
+
+    mode_info_seg = __dpmi_allocate_dos_memory(
+            (sizeof(*mode_info) + 15) / 16,
+            &mode_info_sel);
+    if (mode_info_seg < 0)
+        goto error;
+
+    memset(mode_info, 0, sizeof(*mode_info));
+    dosmemput(mode_info, sizeof(*mode_info), mode_info_seg * 16L);
+
+    memset(&regs, 0, sizeof(regs));
+    regs.x.ax = 0x4F01;
+    regs.x.cx = mode;
+    regs.x.di = 0;
+    regs.x.es = mode_info_seg;
+    (void) __dpmi_int(0x10, &regs);
+
+    if (regs.x.ax != 0x004F)
+        goto error;
+    dosmemget(mode_info_seg * 16L, sizeof(*mode_info), mode_info);
+    if (!(mode_info->ModeAttributes & 0x0001))
+        goto error;
+
+    if (!(mode_info->ModeAttributes & 0x0002))
+    {
+        /* Older VESA BIOS that did not return certain mode properties, but
+           that has fixed mode numbers; search the table to find the right
+           mode properties */
+
+        unsigned i;
+
+        for (i = 0; old_mode_table[i].mode != 0; ++i)
+        {
+            if (mode == old_mode_table[i].mode)
+                break;
+        }
+        if (old_mode_table[i].mode == 0)
+            goto error;
+
+        mode_info->XResolution = old_mode_table[i].XResolution;
+        mode_info->YResolution = old_mode_table[i].YResolution;
+        mode_info->BitsPerPixel = old_mode_table[i].BitsPerPixel;
+        mode_info->NumberOfBanks = 1;
+        switch (mode_info->BitsPerPixel)
+        {
+        case 4:
+            mode_info->NumberOfPlanes = 4;
+            mode_info->MemoryModel = 3;
+            break;
+
+        case 8:
+            mode_info->NumberOfPlanes = 1;
+            mode_info->MemoryModel = 4;
+            break;
+
+        default:
+            mode_info->NumberOfPlanes = 1;
+            mode_info->MemoryModel = 6;
+            break;
+        }
+    }
+
+    __dpmi_free_dos_memory(mode_info_sel);
+    return TRUE;
+
+error:
+    if (mode_info_sel != -1) __dpmi_free_dos_memory(mode_info_sel);
+    return FALSE;
 }

--- a/dosvga/pdcsetsc.c
+++ b/dosvga/pdcsetsc.c
@@ -58,14 +58,15 @@ int PDC_curs_set(int visibility)
             end = _FONT16 - 1;
             break;
         default:  /* normal visibility */
-            start = SP->orig_cursor >> 4;
-            end =   SP->orig_cursor & 0xF;
+            start = SP->orig_cursor >> 8;
+            end =   SP->orig_cursor & 0xFF;
     }
 
     PDC_private_cursor_off();
     PDC_state.cursor_start = start;
     PDC_state.cursor_end = end;
-    PDC_private_cursor_on(PDC_state.cursor_row, PDC_state.cursor_col);
+    if (visibility != 0)
+        PDC_private_cursor_on(PDC_state.cursor_row, PDC_state.cursor_col);
 
     return ret_vis;
 }

--- a/dosvga/pdcsetsc.c
+++ b/dosvga/pdcsetsc.c
@@ -78,7 +78,6 @@ void PDC_set_title(const char *title)
 
 int PDC_set_blink(bool blinkon)
 {
-    COLORS = 16;
     return blinkon ? ERR : OK;
 }
 

--- a/dosvga/pdcsetsc.c
+++ b/dosvga/pdcsetsc.c
@@ -1,0 +1,88 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+/*man-start**************************************************************
+
+pdcsetsc
+--------
+
+### Synopsis
+
+    int PDC_set_blink(bool blinkon);
+    int PDC_set_bold(bool boldon);
+    void PDC_set_title(const char *title);
+
+### Description
+
+   PDC_set_blink() toggles whether the A_BLINK attribute sets an actual
+   blink mode (TRUE), or sets the background color to high intensity
+   (FALSE). The default is platform-dependent (FALSE in most cases). It
+   returns OK if it could set the state to match the given parameter,
+   ERR otherwise. On DOS, this function also adjusts the value of COLORS
+   -- 16 for FALSE, and 8 for TRUE.
+
+   PDC_set_bold() toggles whether the A_BOLD attribute selects an actual
+   bold font (TRUE), or sets the foreground color to high intensity
+   (FALSE). It returns OK if it could set the state to match the given
+   parameter, ERR otherwise.
+
+   PDC_set_title() sets the title of the window in which the curses
+   program is running. This function may not do anything on some
+   platforms.
+
+### Portability
+                             X/Open  ncurses  NetBSD
+    PDC_set_blink               -       -       -
+    PDC_set_title               -       -       -
+
+**man-end****************************************************************/
+
+int PDC_curs_set(int visibility)
+{
+    int ret_vis, start, end;
+
+    PDC_LOG(("PDC_curs_set() - called: visibility=%d\n", visibility));
+
+    ret_vis = SP->visibility;
+    SP->visibility = visibility;
+
+    switch (visibility)
+    {
+        case 0:  /* invisible */
+            start = 1;
+            end = 0;
+            break;
+        case 2:  /* highly visible */
+            start = 0;   /* full-height block */
+            end = _FONT16 - 1;
+            break;
+        default:  /* normal visibility */
+            start = SP->orig_cursor >> 4;
+            end =   SP->orig_cursor & 0xF;
+    }
+
+    PDC_private_cursor_off();
+    PDC_state.cursor_start = start;
+    PDC_state.cursor_end = end;
+    PDC_private_cursor_on(PDC_state.cursor_row, PDC_state.cursor_col);
+
+    return ret_vis;
+}
+
+void PDC_set_title(const char *title)
+{
+    PDC_LOG(("PDC_set_title() - called: <%s>\n", title));
+}
+
+int PDC_set_blink(bool blinkon)
+{
+    COLORS = 16;
+    return blinkon ? ERR : OK;
+}
+
+int PDC_set_bold(bool boldon)
+{
+    /* TODO: support this */
+    return boldon ? ERR : OK;
+}

--- a/dosvga/pdcutil.c
+++ b/dosvga/pdcutil.c
@@ -1,0 +1,103 @@
+/* PDCurses */
+
+#include "pdcdos.h"
+
+void PDC_beep(void)
+{
+    PDCREGS regs;
+
+    PDC_LOG(("PDC_beep() - called\n"));
+
+    regs.W.ax = 0x0e07;       /* Write ^G in TTY fashion */
+    regs.W.bx = 0;
+    PDCINT(0x10, regs);
+}
+
+void PDC_napms(int ms)
+{
+    PDCREGS regs;
+    long goal, start, current;
+
+    PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
+
+    goal = DIVROUND((long)ms, 50);
+    if (!goal)
+        goal++;
+
+    start = getdosmemdword(0x46c);
+
+    goal += start;
+
+    while (goal > (current = getdosmemdword(0x46c)))
+    {
+        if (current < start)    /* in case of midnight reset */
+            return;
+
+        regs.W.ax = 0x1680;
+        PDCINT(0x2f, regs);
+        PDCINT(0x28, regs);
+    }
+}
+
+const char *PDC_sysname(void)
+{
+    return "DOSVGA";
+}
+
+#ifdef __DJGPP__
+
+unsigned char getdosmembyte(int offset)
+{
+    unsigned char b;
+
+    dosmemget(offset, sizeof(unsigned char), &b);
+    return b;
+}
+
+unsigned short getdosmemword(int offset)
+{
+    unsigned short w;
+
+    dosmemget(offset, sizeof(unsigned short), &w);
+    return w;
+}
+
+unsigned long getdosmemdword(int offset)
+{
+    unsigned long dw;
+
+    dosmemget(offset, sizeof(unsigned long), &dw);
+    return dw;
+}
+
+void setdosmembyte(int offset, unsigned char b)
+{
+    dosmemput(&b, sizeof(unsigned char), offset);
+}
+
+void setdosmemword(int offset, unsigned short w)
+{
+    dosmemput(&w, sizeof(unsigned short), offset);
+}
+
+#endif
+
+#if defined(__WATCOMC__) && defined(__386__)
+
+void PDC_dpmi_int(int vector, pdc_dpmi_regs *rmregs)
+{
+    union REGPACK regs = {0};
+
+    rmregs->w.ss = 0;
+    rmregs->w.sp = 0;
+    rmregs->w.flags = 0;
+
+    regs.w.ax = 0x300;
+    regs.h.bl = vector;
+    regs.x.edi = FP_OFF(rmregs);
+    regs.x.es = FP_SEG(rmregs);
+
+    intr(0x31, &regs);
+}
+
+#endif

--- a/dosvga/pdcutil.c
+++ b/dosvga/pdcutil.c
@@ -80,6 +80,11 @@ void setdosmemword(int offset, unsigned short w)
     dosmemput(&w, sizeof(unsigned short), offset);
 }
 
+void setdosmemdword(int offset, unsigned long d)
+{
+    dosmemput(&d, sizeof(unsigned long), offset);
+}
+
 #endif
 
 #if defined(__WATCOMC__) && defined(__386__)

--- a/dosvga/pdcvesa.h
+++ b/dosvga/pdcvesa.h
@@ -76,7 +76,7 @@ struct ModeInfoBlock {
     unsigned char  LinRsvdMaskSize;       /* size of direct color reserved mask (linear modes) */
     unsigned char  LinRsvdFieldPosition;  /* bit position of lsb of reserved mask (linear modes) */
     unsigned long  MaxPixelClock;         /* maximum pixel clock (in Hz) for graphics mode */
-    unsigned char  Reserved4[189];        /* remainder of ModeInfoBlock */
+    unsigned char  Reserved4[190];        /* remainder of ModeInfoBlock */
 };
 #ifdef __GNUC__
 #pragma pack(pop)

--- a/dosvga/pdcvesa.h
+++ b/dosvga/pdcvesa.h
@@ -1,0 +1,88 @@
+/* VESA structures from the VESA BIOS Specification, retrieved 15 Jan 2016
+ * from http://flint.cs.yale.edu/cs422/readings/hardware/vbe3.pdf */
+
+#ifndef PDCVESA_H
+#define PDCVESA_H
+
+#ifdef __GNUC__
+#pragma pack(push, 1)
+#endif
+#ifdef __WATCOMC__
+#pragma pack(__push, 1)
+#endif
+struct VbeInfoBlock {
+    unsigned char  VbeSignature[4];   /* VBE Signature */
+    unsigned short VbeVersion;        /* VBE Version */
+    unsigned long  OemStringPtr;      /* VbeFarPtr to OEM String */
+    unsigned long  Capabilities;      /* Capabilities of graphics controller */
+    unsigned long  VideoModePtr;      /* VbeFarPtr to VideoModeList */
+    unsigned short TotalMemory;       /* Number of 64kb memory blocks */
+    /* Added for VBE 2.0+ */
+    unsigned short OemSoftwareRev;    /* VBE implementation Software revision */
+    unsigned long  OemVendorNamePtr;  /* VbeFarPtr to Vendor Name String */
+    unsigned long  OemProductNamePtr; /* VbeFarPtr to Product Name String */
+    unsigned long  OemProductRevPtr;  /* VbeFarPtr to Product Revision String */
+    unsigned char  Reserved[222];     /* Reserved for VBE implementation scratch area */
+    unsigned char  OemData[256];      /* Data Area for OEM Strings */
+};
+
+struct ModeInfoBlock {
+    /* Mandatory information for all VBE revisions */
+    unsigned short ModeAttributes;        /* mode attributes */
+    unsigned char  WinAAttributes;        /* window A attributes */
+    unsigned char  WinBAttributes;        /* window B attributes */
+    unsigned short WinGranularity;        /* window granularity */
+    unsigned short WinSize;               /* window size */
+    unsigned short WinASegment;           /* window A start segment */
+    unsigned short WinBSegment;           /* window B start segment */
+    unsigned long  WinFuncPtr;            /* real mode pointer to window function */
+    unsigned short BytesPerScanLine;      /* bytes per scan line */
+    /* Mandatory information for VBE 1.2 and above */
+    unsigned short XResolution;           /* horizontal resolution in pixels or characters */
+    unsigned short YResolution;           /* vertical resolution in pixels or characters */
+    unsigned char  XCharSize;             /* character cell width in pixels */
+    unsigned char  YCharSize;             /* character cell height in pixels */
+    unsigned char  NumberOfPlanes;        /* number of memory planes */
+    unsigned char  BitsPerPixel;          /* bits per pixel */
+    unsigned char  NumberOfBanks;         /* number of banks */
+    unsigned char  MemoryModel;           /* memory model type */
+    unsigned char  BankSize;              /* bank size in KB */
+    unsigned char  NumberOfImagePages;    /* number of images */
+    unsigned char  Reserved1;             /* reserved for page function */
+    /* Direct Color fields (required for direct/6 and YUV/7 memory models) */
+    unsigned char  RedMaskSize;           /* size of direct color red mask in bits */
+    unsigned char  RedFieldPosition;      /* bit position of lsb of red mask */
+    unsigned char  GreenMaskSize;         /* size of direct color green mask in bits */
+    unsigned char  GreenFieldPosition;    /* bit position of lsb of green mask */
+    unsigned char  BlueMaskSize;          /* size of direct color blue mask in bits */
+    unsigned char  BlueFieldPosition;     /* bit position of lsb of blue mask */
+    unsigned char  RsvdMaskSize;          /* size of direct color reserved mask in bits */
+    unsigned char  RsvdFieldPosition;     /* bit position of lsb of reserved mask */
+    unsigned char  DirectColorModeInfo;   /* direct color mode attributes */
+    /* Mandatory information for VBE 2.0 and above */
+    unsigned long  PhysBasePtr;           /* physical address for flat memory frame buffer */
+    unsigned long  Reserved2;             /* Reserved - always set to 0 */
+    unsigned short Reserved3;             /* Reserved - always set to 0 */
+    /* Mandatory information for VBE 3.0 and above */
+    unsigned short LinBytesPerScanLine;   /* bytes per scan line for linear modes */
+    unsigned char  BnkNumberOfImagePages; /* number of images for banked modes */
+    unsigned char  LinNumberOfImagePages; /* number of images for linear modes */
+    unsigned char  LinRedMaskSize;        /* size of direct color red mask (linear modes) */
+    unsigned char  LinRedFieldPosition;   /* bit position of lsb of red mask (linear modes) */
+    unsigned char  LinGreenMaskSize;      /* size of direct color green mask  (linear modes) */
+    unsigned char  LinGreenFieldPosition; /* bit position of lsb of green mask (linear modes) */
+    unsigned char  LinBlueMaskSize;       /* size of direct color blue mask  (linear modes) */
+    unsigned char  LinBlueFieldPosition;  /* bit position of lsb of blue mask (linear modes) */
+    unsigned char  LinRsvdMaskSize;       /* size of direct color reserved mask (linear modes) */
+    unsigned char  LinRsvdFieldPosition;  /* bit position of lsb of reserved mask (linear modes) */
+    unsigned long  MaxPixelClock;         /* maximum pixel clock (in Hz) for graphics mode */
+    unsigned char  Reserved4[189];        /* remainder of ModeInfoBlock */
+};
+#ifdef __GNUC__
+#pragma pack(pop)
+#endif
+#ifdef __WATCOMC__
+#pragma pack(__pop)
+#endif
+
+#endif


### PR DESCRIPTION
This port compiles on MS-DOS, using the DJGPP, Watcom (16 or 32 bit) or Borland (16 bit only) compilers. It expects to find a VGA, and switches it to graphical mode to display the text.

If it finds VESA BIOS Extensions, it can use them to produce a larger display. The font size is fixed at 8 by 16 pixels.

It supports A_UNDERLINE, A_LEFT and A_RIGHT. Blink is mapped to bright background.

A correction to the testcurs.c demo is included, to fix an integer overflow in the extended color test.