### PR TITLE
Implement SDL1 and SDL2 shared libraries

### DIFF
--- a/sdl1/Makefile
+++ b/sdl1/Makefile
@@ -36,6 +36,7 @@ LINK		= $(CC)
 LDFLAGS		= $(LIBCURSES) $(SLIBS)
 RANLIB		= ranlib
 LIBCURSES	= pdcurses.a
+LIBCURSES_SO	= pdcurses.so
 
 DEMOS		+= sdltest
 
@@ -43,7 +44,7 @@ DEMOS		+= sdltest
 
 all:	libs
 
-libs:	$(LIBCURSES)
+libs:	$(LIBCURSES) $(LIBCURSES_SO)
 
 clean:
 	-rm -rf *.o trace $(LIBCURSES) $(DEMOS)
@@ -56,6 +57,9 @@ endif
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	ar rv $@ $?
 	-$(RANLIB) $@
+
+$(LIBCURSES_SO) : $(LIBOBJS) $(PDCOBJS)
+	$(CC) -shared -o $@ $? $(SLIBS)
 
 $(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
 $(PDCOBJS) : $(PDCURSES_SDL_H)

--- a/sdl1/Makefile
+++ b/sdl1/Makefile
@@ -47,7 +47,7 @@ all:	libs
 libs:	$(LIBCURSES) $(LIBCURSES_SO)
 
 clean:
-	-rm -rf *.o trace $(LIBCURSES) $(DEMOS)
+	-rm -rf *.o trace $(LIBCURSES) $(LIBCURSES_SO) $(DEMOS)
 
 demos:	$(DEMOS)
 ifneq ($(DEBUG),Y)

--- a/sdl1/README.md
+++ b/sdl1/README.md
@@ -9,8 +9,8 @@ Building
 
 - On *nix (including Linux), run "make" in the sdl1 directory. There is
   no configure script (yet?) for this port. This assumes a working
-  sdl-config, and GNU make. It builds the library pdcurses.a (dynamic
-  lib not implemented).
+  sdl-config, and GNU make. It builds the libraries pdcurses.a and
+  pdcurses.so.
 
 - The makefile accepts the optional parameter "DEBUG=Y", and recognizes
   the optional PDCURSES_SRCDIR environment variable, as with the console

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -64,11 +64,20 @@ ifeq ($(OS)_$(DLL),Windows_NT_Y)
 	LIBLIBS = $(SLIBS)
 	LDFLAGS = $(LIBCURSES)
 else
+ifeq ($(SHARED),Y)
+	LIBEXE = $(CC)
+	LIBFLAGS = -shared -o
+	LIBCURSES = pdcurses.so
+	LIBLIBS = $(SLIBS)
+	LDFLAGS = $(LIBCURSES)
+	CLEAN = *.so
+else
 	LIBEXE = $(AR)
 	LIBFLAGS = rcv
 	LIBCURSES = pdcurses.a
 	LDFLAGS = $(LIBCURSES) $(SLIBS)
 	CLEAN = *.a
+endif
 endif
 
 BUILD		= $(CC) $(CFLAGS) -I$(PDCURSES_SRCDIR)

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -55,7 +55,7 @@ ifeq ($(UTF8),Y)
 endif
 
 ifeq ($(DLL),Y)
-	ifeq ($(OS),Windows)
+	ifeq ($(OS),Windows_NT)
 		CFLAGS += -DPDC_DLL_BUILD
 		LIBEXE = $(CC)
 		LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -64,20 +64,25 @@ ifeq ($(OS)_$(DLL),Windows_NT_Y)
 	LIBLIBS = $(SLIBS)
 	LDFLAGS = $(LIBCURSES)
 else
-ifeq ($(SHARED),Y)
-	LIBEXE = $(CC)
-	LIBFLAGS = -shared -o
-	LIBCURSES = pdcurses.so
-	LIBLIBS = $(SLIBS)
-	LDFLAGS = $(LIBCURSES)
-	CLEAN = *.so
-else
-	LIBEXE = $(AR)
-	LIBFLAGS = rcv
-	LIBCURSES = pdcurses.a
-	LDFLAGS = $(LIBCURSES) $(SLIBS)
-	CLEAN = *.a
-endif
+	ifeq ($(SHARED),Y)
+		ifeq ($(shell uname -s),Darwin)
+			SHARED_SUFFIX = .dylib
+		else
+			SHARED_SUFFIX = .so
+		endif
+		LIBEXE = $(CC)
+		LIBFLAGS = -shared -o
+		LIBCURSES = pdcurses$(SHARED_SUFFIX)
+		LIBLIBS = $(SLIBS)
+		LDFLAGS = $(LIBCURSES)
+		CLEAN = *$(SHARED_SUFFIX)
+	else
+		LIBEXE = $(AR)
+		LIBFLAGS = rcv
+		LIBCURSES = pdcurses.a
+		LDFLAGS = $(LIBCURSES) $(SLIBS)
+		CLEAN = *.a
+	endif
 endif
 
 BUILD		= $(CC) $(CFLAGS) -I$(PDCURSES_SRCDIR)

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -54,35 +54,35 @@ ifeq ($(UTF8),Y)
 	CFLAGS += -DPDC_FORCE_UTF8
 endif
 
-ifeq ($(OS)_$(DLL),Windows_NT_Y)
-	CFLAGS += -DPDC_DLL_BUILD
-	LIBEXE = $(CC)
-	LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o
-	LIBCURSES = pdcurses.dll
-	CLEAN = $(LIBCURSES) *.a
-	RESOURCE = pdcurses.o
-	LIBLIBS = $(SLIBS)
-	LDFLAGS = $(LIBCURSES)
-else
-	ifeq ($(SHARED),Y)
+ifeq ($(DLL),Y)
+	ifeq ($(OS),Windows)
+		CFLAGS += -DPDC_DLL_BUILD
+		LIBEXE = $(CC)
+		LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o
+		LIBCURSES = pdcurses.dll
+		CLEAN = $(LIBCURSES) *.a
+		RESOURCE = pdcurses.o
+		LIBLIBS = $(SLIBS)
+		LDFLAGS = $(LIBCURSES)
+	else
 		ifeq ($(shell uname -s),Darwin)
-			SHARED_SUFFIX = .dylib
+			DLL_SUFFIX = .dylib
 		else
-			SHARED_SUFFIX = .so
+			DLL_SUFFIX = .so
 		endif
 		LIBEXE = $(CC)
 		LIBFLAGS = -shared -o
-		LIBCURSES = pdcurses$(SHARED_SUFFIX)
+		LIBCURSES = pdcurses$(DLL_SUFFIX)
 		LIBLIBS = $(SLIBS)
 		LDFLAGS = $(LIBCURSES)
-		CLEAN = *$(SHARED_SUFFIX)
-	else
-		LIBEXE = $(AR)
-		LIBFLAGS = rcv
-		LIBCURSES = pdcurses.a
-		LDFLAGS = $(LIBCURSES) $(SLIBS)
-		CLEAN = *.a
+		CLEAN = *$(DLL_SUFFIX)
 	endif
+else
+	LIBEXE = $(AR)
+	LIBFLAGS = rcv
+	LIBCURSES = pdcurses.a
+	LDFLAGS = $(LIBCURSES) $(SLIBS)
+	CLEAN = *.a
 endif
 
 BUILD		= $(CC) $(CFLAGS) -I$(PDCURSES_SRCDIR)

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -10,7 +10,7 @@ Building
 - On *nix (including Linux and Mac OS X), run "make" in the sdl2
   directory. There is no configure script (yet?) for this port. This
   assumes a working sdl-config, and GNU make. It builds the library
-  pdcurses.a (or pdcurses.so with SHARED=Y).
+  pdcurses.a (or pdcurses.so/pdcurses.dylib with SHARED=Y).
 
 - With MinGW, edit the Makefile to point to the appropriate include and
   library paths, and then run "mingw32-make".
@@ -25,9 +25,9 @@ Building
   and treat all narrow-character strings as UTF-8; this option has no
   effect unless WIDE=Y is also set. Under Windows, you can specify
   "DLL=Y" to build pdcurses.dll instead of a static library. Under *nix,
-  you can specify "SHARED=Y" to build pdcurses.so rather than the static
-  library. And on all platforms, add the target "demos" to build the
-  sample programs.
+  you can specify "SHARED=Y" to build pdcurses.so or pdcurses.dylib
+  rather than the static library. And on all platforms, add the target
+  "demos" to build the sample programs.
 
 
 Usage

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -10,7 +10,7 @@ Building
 - On *nix (including Linux and Mac OS X), run "make" in the sdl2
   directory. There is no configure script (yet?) for this port. This
   assumes a working sdl-config, and GNU make. It builds the library
-  pdcurses.a (or pdcurses.so/pdcurses.dylib with SHARED=Y).
+  pdcurses.a (or pdcurses.so/pdcurses.dylib with DLL=Y).
 
 - With MinGW, edit the Makefile to point to the appropriate include and
   library paths, and then run "mingw32-make".
@@ -23,11 +23,10 @@ Building
   characters, but depends on the SDL2_ttf library, instead of using
   simple bitmap fonts. "UTF8=Y" makes PDCurses ignore the system locale,
   and treat all narrow-character strings as UTF-8; this option has no
-  effect unless WIDE=Y is also set. Under Windows, you can specify
-  "DLL=Y" to build pdcurses.dll instead of a static library. Under *nix,
-  you can specify "SHARED=Y" to build pdcurses.so or pdcurses.dylib
-  rather than the static library. And on all platforms, add the target
-  "demos" to build the sample programs.
+  effect unless WIDE=Y is also set. You can specify "DLL=Y" to build a dynamic
+  rather than static library. The dynamic library is called pdcurses.dll,
+  pdcurses.so, or pdcurses.dylib on Windows, Linux, or Mac OS X respectively.
+  And on all platforms, add the target "demos" to build the sample programs.
 
 
 Usage

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -10,7 +10,7 @@ Building
 - On *nix (including Linux and Mac OS X), run "make" in the sdl2
   directory. There is no configure script (yet?) for this port. This
   assumes a working sdl-config, and GNU make. It builds the library
-  pdcurses.a (dynamic lib not implemented).
+  pdcurses.a (or pdcurses.so with SHARED=Y).
 
 - With MinGW, edit the Makefile to point to the appropriate include and
   library paths, and then run "mingw32-make".
@@ -24,8 +24,10 @@ Building
   simple bitmap fonts. "UTF8=Y" makes PDCurses ignore the system locale,
   and treat all narrow-character strings as UTF-8; this option has no
   effect unless WIDE=Y is also set. Under Windows, you can specify
-  "DLL=Y" to build pdcurses.dll instead a static library. And on all
-  platforms, add the target "demos" to build the sample programs.
+  "DLL=Y" to build pdcurses.dll instead of a static library. Under *nix,
+  you can specify "SHARED=Y" to build pdcurses.so rather than the static
+  library. And on all platforms, add the target "demos" to build the
+  sample programs.
 
 
 Usage


### PR DESCRIPTION
* SDL1: `make libs` now makes pdcurses.so in addition to pdcurses.a.
* SDL2: You can build pdcurses.so/pdcurses.dylib with `make DLL=Y`. You can only build either pdcurses.a or pdcurses.so, consistent with the rest of the Makefile.