### PR TITLE
Fix non-wide sdl2 font coloration

### DIFF
--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -3,6 +3,7 @@
 #include "pdcsdl.h"
 
 #include <stdlib.h>
+#include <limits.h>
 #ifndef PDC_WIDE
 # include "../common/font437.h"
 #endif
@@ -36,6 +37,83 @@ SDL_Color pdc_color[PDC_MAXCOL];
 Uint32 pdc_mapped[PDC_MAXCOL];
 int pdc_fheight, pdc_fwidth, pdc_fthick, pdc_flastc;
 bool pdc_own_window;
+
+#ifndef PDC_WIDE
+
+/* Load a bitmap from bmp_rw and also determine its palette size.
+   ->format->palette->ncolors may be greater than the actual size.
+   To get the real palette size, some custom bitmap parsing is needed. */
+
+static SDL_Surface *_load_bmp_and_palette_size(SDL_RWops *bmp_rw, int *sizep)
+{
+    SDL_Surface *bmp = NULL;
+    int palette_size = -1;
+    Sint64 start_offset;
+
+    if (!bmp_rw)
+        goto error_rw;
+
+    start_offset = SDL_RWtell(bmp_rw);
+    if (start_offset < 0)
+        goto error_reading;
+
+    bmp = SDL_LoadBMP_RW(bmp_rw, 0);
+    if (!bmp)
+        goto error_reading;
+
+    /* Non-monochromatic bitmaps only */
+    if (bmp->format->palette)
+    {
+        Uint32 header_size;
+
+        palette_size = bmp->format->palette->ncolors;
+
+        /* Offsets from https://en.wikipedia.org/wiki/BMP_file_format#DIB_header_(bitmap_information_header) */
+        if (SDL_RWseek(bmp_rw, start_offset + 14, RW_SEEK_SET) < 0)
+            goto error_reading;
+        header_size = SDL_ReadLE32(bmp_rw);
+
+        /* If the info header is at least 40 bytes in size, palette size
+           information is available. */
+        if (header_size >= 40)
+        {
+            Uint32 num_colors;
+
+            if (SDL_RWseek(bmp_rw, start_offset + 46, RW_SEEK_SET) < 0)
+                goto error_reading;
+            num_colors = SDL_ReadLE32(bmp_rw);
+
+            if (num_colors > 0 && num_colors <= (Uint32)INT_MAX &&
+                (int)num_colors <= bmp->format->palette->ncolors)
+                palette_size = (int)num_colors;
+            else
+            {
+                /* Fall back to calculating num_colors from bits_per_pixel. */
+
+                Uint16 bits_per_pixel;
+
+                if (SDL_RWseek(bmp_rw, start_offset + 28, RW_SEEK_SET) < 0)
+                    goto error_reading;
+                bits_per_pixel = SDL_ReadLE16(bmp_rw);
+
+                num_colors = (Uint32)1 << bits_per_pixel;
+
+                if (num_colors > 0 && num_colors <= (Uint32)INT_MAX &&
+                    (int)num_colors <= bmp->format->palette->ncolors)
+                    palette_size = (int)num_colors;
+            }
+        }
+    }
+
+error_reading:
+    SDL_RWclose(bmp_rw);
+
+error_rw:
+    *sizep = palette_size;
+    return bmp;
+}
+
+#endif
 
 static void _clean(void)
 {
@@ -211,19 +289,32 @@ int PDC_scr_open(void)
 
     SP->mono = FALSE;
 #else
-    if (!pdc_font)
+    if (pdc_font)
     {
-        const char *fname = getenv("PDC_FONT");
-        pdc_font = SDL_LoadBMP(fname ? fname : "pdcfont.bmp");
+        if (pdc_font->format->palette)
+            pdc_flastc = pdc_font->format->palette->ncolors - 1;
     }
-
-    if (!pdc_font)
-        pdc_font = SDL_LoadBMP_RW(SDL_RWFromMem(font437, sizeof(font437)), 0);
-
-    if (!pdc_font)
+    else
     {
-        fprintf(stderr, "Could not load font\n");
-        return ERR;
+        int palette_size;
+
+        const char *fname = getenv("PDC_FONT");
+        SDL_RWops *file = SDL_RWFromFile(fname ? fname : "pdcfont.bmp", "r");
+        if (file)
+            pdc_font = _load_bmp_and_palette_size(file, &palette_size);
+
+        if (!pdc_font)
+            pdc_font = _load_bmp_and_palette_size(
+                SDL_RWFromMem(font437, sizeof(font437)), &palette_size);
+
+        if (!pdc_font)
+        {
+            fprintf(stderr, "Could not load font\n");
+            return ERR;
+        }
+
+        if (pdc_font->format->palette)
+            pdc_flastc = palette_size - 1;
     }
 
     SP->mono = !pdc_font->format->palette;
@@ -251,9 +342,6 @@ int PDC_scr_open(void)
     pdc_fheight = pdc_font->h / 8;
     pdc_fwidth = pdc_font->w / 32;
     pdc_fthick = 1;
-
-    if (!SP->mono)
-        pdc_flastc = pdc_font->format->palette->ncolors - 1;
 #endif
 
     if (pdc_own_window && !pdc_icon)


### PR DESCRIPTION
# Overview

This is essentially the same patch as https://github.com/Bill-Gray/PDCursesMod/pull/207

With SDL 2.0.14, it seems like the palette size of a loaded bitmap surface is larger than the palette size of the actual bitmap. Therefore, the last color in the palette never actually shows up in the font. This leads to characters not being properly colored.

This patch adds some complex code because it needs to parse part of the bitmap itself. A much simpler way to fix this issue would be to use the first and second palette entries rather than the first and last, but doing so would break custom fonts with more than two colors.

# Images

These images can give you an idea of what this patch fixes.

## Built-in Font

### Before

![before1](https://user-images.githubusercontent.com/28828704/122085499-c52ec380-cdd0-11eb-9e1d-b7729dbdb315.png)

### After

![after1](https://user-images.githubusercontent.com/28828704/122085535-cd86fe80-cdd0-11eb-86c5-b7e33de75a18.png)

## Custom Font

I just added red bits to "A" and "B".

### Before

![before2](https://user-images.githubusercontent.com/28828704/122085548-d4157600-cdd0-11eb-947f-ea36c7e69727.png)

### After

![after2](https://user-images.githubusercontent.com/28828704/122085583-db3c8400-cdd0-11eb-9896-3841ab764510.png)

# Font Files

These are the fonts I used for testing.

* [modified437.bmp.gz](https://github.com/wmcbrine/PDCurses/files/6657019/modified437.bmp.gz): The modified font used in the above images.
* [modified437bpp.bmp.gz](https://github.com/wmcbrine/PDCurses/files/6657029/modified437bpp.bmp.gz): Identical to the font above except in the way its palette size is determined. The font file above contains the palette size. This font file only contains the bits per pixel, which can be used to determine the palette size.
* [modified437invalid.bmp.gz](https://github.com/wmcbrine/PDCurses/files/6657041/modified437invalid.bmp.gz): This font file cannot be loaded. I used it to test that the built-in font is still loaded as a fallback.


