### PR TITLE
Improve x11 font compatibility

### DIFF
--- a/x11/pdcscrn.c
+++ b/x11/pdcscrn.c
@@ -503,22 +503,23 @@ int PDC_scr_open(void)
 
     /* Check application resource values here */
 
-    pdc_fwidth = pdc_app_data.normalFont->max_bounds.rbearing -
-                 pdc_app_data.normalFont->min_bounds.lbearing;
+    pdc_fwidth = pdc_app_data.normalFont->max_bounds.width;
 
-    pdc_fascent = pdc_app_data.normalFont->max_bounds.ascent;
-    pdc_fdescent = pdc_app_data.normalFont->max_bounds.descent;
+    pdc_fascent = pdc_app_data.normalFont->ascent;
+    pdc_fdescent = pdc_app_data.normalFont->descent;
     pdc_fheight = pdc_fascent + pdc_fdescent;
 
     /* Check that the italic font and normal fonts are the same size */
 
-    italic_font_valid = pdc_fwidth ==
-        pdc_app_data.italicFont->max_bounds.rbearing -
-        pdc_app_data.italicFont->min_bounds.lbearing;
+    italic_font_valid =
+        pdc_fwidth == pdc_app_data.italicFont->max_bounds.width &&
+        pdc_fheight ==
+            pdc_app_data.italicFont->ascent + pdc_app_data.italicFont->descent;
 
-    bold_font_valid = pdc_fwidth ==
-        pdc_app_data.boldFont->max_bounds.rbearing -
-        pdc_app_data.boldFont->min_bounds.lbearing;
+    bold_font_valid =
+        pdc_fwidth == pdc_app_data.boldFont->max_bounds.width &&
+        pdc_fheight ==
+            pdc_app_data.boldFont->ascent + pdc_app_data.boldFont->descent;
 
     /* Calculate size of display window */
 


### PR DESCRIPTION
This is just the same PR as https://github.com/Bill-Gray/PDCursesMod/pull/210 combined with the addition suggested by @Bill-Gray. The description for that PR pretty much applies here. These are some pictures of the bug:

With the Raspbian/LXDE fallback font:
![2021-06-19-151410_960x408](https://user-images.githubusercontent.com/28828704/122647513-119d3a80-d114-11eb-9d4c-1f5b408d1184.png)

With `lucidasanstypewriter-10`:
![2021-06-19-151302_880x384](https://user-images.githubusercontent.com/28828704/122647522-182bb200-d114-11eb-95be-8c18e9bdf6bc.png)