### PR TITLE
Handle KEY_BACKSPACE in tui.c for tuidemo

### DIFF
--- a/demos/tui.c
+++ b/demos/tui.c
@@ -689,7 +689,11 @@ int weditstr(WINDOW *win, char *buf, int field)
             break;
 
         default:
-            if (c == erasechar())       /* backspace, ^H */
+            /* check KEY_BACKSPACE manually, because erasechar() can only
+             * return char, and KEY_BACKSPACE is an int, so on systems
+             * that truly return KEY_BACKSPACE from wgetch(), we'll never
+             * catch it with erasechar() */
+            if (c == erasechar() || c == KEY_BACKSPACE)
             {
                 if (bp > buf)
                 {


### PR DESCRIPTION
Due to the erasechar() API, which returns char, and wgetch(), which
returns int, and KEY_BACKSPACE, which is int, it is incorrect
to completely rely on erasechar() for backspace support.
If some systems truly return KEY_BACKSPACE, then checking against
erasechar() alone will never catch the true return value.

This is primarily a compatibility fix for people like me who test
the demos with other curses libraries.  It worked fine in PDCurses,
but not ncurses.