### PR TITLE
Fixed: access violation reading | prefresh 

### DIFF
--- a/pdcurses/pad.c
+++ b/pdcurses/pad.c
@@ -193,9 +193,9 @@ int pnoutrefresh(WINDOW *w, int py, int px, int sy1, int sx1, int sy2, int sx2)
     if (sx1 < 0)
         sx1 = 0;
 
-    if (!w || !(w->_flags & (_PAD|_SUBPAD)) || 
+    if ((!w || !(w->_flags & (_PAD|_SUBPAD)) || 
         (sy2 >= LINES) || (sx2 >= COLS)) ||
-        (sy2 < sy1) || (sx2 < sx1)
+        (sy2 < sy1) || (sx2 < sx1))
         return ERR;
 
     sline = sy1;


### PR DESCRIPTION
I use the latest 3.9 binaries of PDCurses with a python library called [unicurses](https://github.com/unicurses/unicurses) and I found out that when using `prefresh` with `py` set to negative numbers throws `OSError: exception: access violation reading 0xFFFFFFFFFFFFFFFF` and this seems to be because both of the variables below are set to the negative value of `sy1` and `py`  *(accordingly)* before changing to `0`:
```c
int sline = sy1; 
int pline = py;
```
*(I haven't recompiled or tested it yet, but it looks pretty obvious ... 😛 )*