### PR TITLE
FIXED: pads with panels

### DIFF
--- a/curses.h
+++ b/curses.h
@@ -300,6 +300,17 @@ typedef struct _win       /* definition of a window */
     int   _delayms;       /* milliseconds of delay for getch() */
     int   _parx, _pary;   /* coords relative to parent (0,0) */
     struct _win *_parent; /* subwin's pointer to parent win */
+
+    /* these are used only if this is a pad */
+    struct pdat           
+    {
+        int _pad_y;         
+        int _pad_x;
+        int _pad_top;
+        int _pad_left;
+        int _pad_bottom;
+        int _pad_right;
+    } _pad;               /* Pad-properties structure */
 } WINDOW;
 
 /* Color pair structure */

--- a/pdcurses/refresh.c
+++ b/pdcurses/refresh.c
@@ -64,8 +64,16 @@ int wnoutrefresh(WINDOW *win)
 
     PDC_LOG(("wnoutrefresh() - called: win=%p\n", win));
 
-    if ( !win || (win->_flags & (_PAD|_SUBPAD)) )
+    if (!win)
         return ERR;
+    if (is_pad(win))
+        return pnoutrefresh(win,
+				win->_pad._pad_y,
+				win->_pad._pad_x,
+				win->_pad._pad_top,
+				win->_pad._pad_left,
+				win->_pad._pad_bottom,
+				win->_pad._pad_right);
 
     begy = win->_begy;
     begx = win->_begx;

--- a/pdcurses/window.c
+++ b/pdcurses/window.c
@@ -185,6 +185,15 @@ WINDOW *PDC_makenew(int nlines, int ncols, int begy, int begx)
     win->_bmarg = nlines - 1;
     win->_parx = win->_pary = -1;
 
+    /* initialize pad variables*/
+
+    win->_pad._pad_y = -1;
+    win->_pad._pad_x = -1;
+    win->_pad._pad_top = -1;
+    win->_pad._pad_left = -1;
+    win->_pad._pad_bottom = -1;
+    win->_pad._pad_right = -1;
+
     /* init to say window all changed */
 
     touchwin(win);


### PR DESCRIPTION
Based on NCurses and what was discussed here https://github.com/wmcbrine/PDCurses/issues/124 I think i fixed the issue. I haven't excessively tested it, but seems to work fine with this simple example:
```c
#include <curses.h>
#include <panel.h>

int main( void)
{
    int ch = -1;
    WINDOW *pad1;
    WINDOW *pad2;
    PANEL  *panel1;
    PANEL  *panel2;

    initscr    ();
    noecho     ();
    start_color();
    
    init_pair(1, COLOR_BLUE , COLOR_RED  );
    init_pair(2, COLOR_WHITE, COLOR_GREEN);
    keypad(stdscr, TRUE);

    refresh();

    pad1 = newpad(10,10);
    pad2 = newpad(10,15);
    
    wbkgd   (pad1, COLOR_PAIR(1));
    wbkgd   (pad2, COLOR_PAIR(2));
    waddstr (pad1,"Test 1.");
    waddstr (pad2,"Test 2.");
    prefresh(pad1, 0, 0, 1, 2, 4 , 9 );
    prefresh(pad2, 0, 0, 3, 6, 8 , 18);

    panel1 = new_panel(pad1);
    panel2 = new_panel(pad2);

    while(ch != 'q' && ch != 'Q')
    {
        ch = getch();
        
        if      (ch == KEY_UP  )  show_panel(panel1); 
        else if (ch == KEY_DOWN)  hide_panel(panel1); 
        else if (ch == KEY_LEFT)  show_panel(panel2); 
        else if (ch == KEY_RIGHT) hide_panel(panel2); 

        update_panels();
        doupdate();
    }
    endwin( );
    return(0);
}
```
![pdcursesFIXEbug1 gif](https://user-images.githubusercontent.com/11987271/142761526-c69fc110-dc98-4d7e-b920-b68961c20db1.gif)

**PS.** One thing I was not sure was if I needed to add `free(win->_pad)` inside `delwin` function but nvm *(i'm kinda noob when it comes to C)*