### PR TITLE
Allow C++ compilation of curspriv.h

### DIFF
--- a/curspriv.h
+++ b/curspriv.h
@@ -7,6 +7,10 @@
 #define CURSES_LIBRARY
 #include <curses.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(__TURBOC__) || defined(__EMX__) || defined(__DJGPP__) || \
     defined(PDC_99) || defined(__WATCOMC__)
 # ifndef HAVE_VSSCANF
@@ -118,5 +122,9 @@ size_t  PDC_wcstombs(char *, const wchar_t *, size_t);
 
 #define _INBUFSIZ        512  /* size of terminal input buffer */
 #define NUNGETCH         256  /* max # chars to ungetch() */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CURSES_INTERNALS__ */


### PR DESCRIPTION
I'm working on a modified SDL2 backend with .cpp source files and needed this small change.