### PR TITLE
Fix crashes with windows overlapping right and bottom edges of screen

### DIFF
--- a/pdcurses/refresh.c
+++ b/pdcurses/refresh.c
@@ -78,7 +78,7 @@ int wnoutrefresh(WINDOW *win)
     begy = win->_begy;
     begx = win->_begx;
 
-    for (i = 0, j = begy; i < win->_maxy; i++, j++)
+    for (i = 0, j = begy; i < win->_maxy && j < curscr->_maxy; i++, j++)
     {
         if (win->_firstch[i] != _NO_CHANGE)
         {
@@ -87,6 +87,9 @@ int wnoutrefresh(WINDOW *win)
 
             int first = win->_firstch[i]; /* first changed */
             int last = win->_lastch[i];   /* last changed */
+
+            if( last > curscr->_maxx - begx - 1)    /* don't run off right-hand */
+                last = curscr->_maxx - begx - 1;    /* edge of screen */
 
             /* ignore areas on the outside that are marked as changed,
                but really aren't */
@@ -128,6 +131,10 @@ int wnoutrefresh(WINDOW *win)
     {
         curscr->_cury = win->_cury + begy;
         curscr->_curx = win->_curx + begx;
+        if( win->_cury >= win->_maxy)
+            win->_cury = win->_maxy - 1;
+        if( win->_curx >= win->_maxx)
+            win->_curx = win->_maxx - 1;
     }
 
     return OK;

--- a/pdcurses/window.c
+++ b/pdcurses/window.c
@@ -273,7 +273,7 @@ WINDOW *newwin(int nlines, int ncols, int begy, int begx)
     if (!ncols)
         ncols  = COLS  - begx;
 
-    if (!SP || begy + nlines > SP->lines || begx + ncols > SP->cols)
+    if (!SP)
         return (WINDOW *)NULL;
 
     win = PDC_makenew(nlines, ncols, begy, begx);
@@ -314,8 +314,7 @@ int mvwin(WINDOW *win, int y, int x)
 {
     PDC_LOG(("mvwin() - called\n"));
 
-    if (!win || (y + win->_maxy > LINES || y < 0)
-             || (x + win->_maxx > COLS || x < 0))
+    if (!win || y < 0 || x < 0)
         return ERR;
 
     win->_begy = y;


### PR DESCRIPTION
`ncurses` allows one to create,  move,  and resize windows to extend past the right and bottom edges of the screen.  PDCurses doesn't allow you to create or move such windows.  It will allow you to _attempt_ to resize past those edges and will return a valid window,  but will segfault when that window is updated;  see issues #162 and #85.  This patch fixes both issues.

With ports supporting resizable screens,  you also got crashes if the screen is shrunk such that an existing window sticks past the right or bottom edge.  That's also now fixed.

The first commit simply says that when refreshing a window,  stop copying data when you reach the right and bottom edges of `curscr`.  (At present,  there's no way I can see to get windows to go past the left or top edges.)

The second commit,  recognizing that such windows can now be displayed without crashing,  removes the limits in `newwin()` and `mvwin()`.  `resize_window()`,  as noted above,  already had no such limits.)