### PR TITLE
x11: Fix broken `-c -o` test in configure script

### DIFF
--- a/x11/aclocal.m4
+++ b/x11/aclocal.m4
@@ -495,7 +495,7 @@ changequote(, )dnl
 		       sed -e 's/[^a-zA-Z0-9_]/_/g' -e 's/^[0-9]/_/'`"
 changequote([, ])dnl
 AC_CACHE_VAL(ac_cv_prog_cc_${ac_cc}_c_o,
-[echo 'foo(){}' > conftest.c
+[echo 'int foo(){}' > conftest.c
 # We do the test twice because some compilers refuse to overwrite an
 # existing .o file with -o, though they will create one.
 eval ac_cv_prog_cc_${ac_cc}_c_o=no

--- a/x11/configure
+++ b/x11/configure
@@ -3816,7 +3816,7 @@ set dummy $CC; ac_cc="`echo $2 |
 if eval \${ac_cv_prog_cc_${ac_cc}_c_o+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  echo 'foo(){}' > conftest.c
+  echo 'int foo(){}' > conftest.c
 # We do the test twice because some compilers refuse to overwrite an
 # existing .o file with -o, though they will create one.
 eval ac_cv_prog_cc_${ac_cc}_c_o=no


### PR DESCRIPTION
Recent versions of gcc now consider it an error to declare a function without a return type, so `foo(){}` is no longer a valid function definition. The following is an example from `config.log`:
```
configure:3812: checking whether gcc understand -c and -o together
configure:3824: gcc -c conftest.c -o conftest.ooo 1>&5
conftest.c:1:1: error: return type defaults to 'int' [-Wimplicit-int]
    1 | foo(){}
      | ^~~
configure:3827: $? = 1
configure:3861: result: no
```
Thus, this test was always failing even though gcc obviously handles the `-c` and `-o` options together. Adding a return type fixes the bug.